### PR TITLE
feat: disable rare GSM bands

### DIFF
--- a/packages/core/src/radio/gsm.ts
+++ b/packages/core/src/radio/gsm.ts
@@ -12,6 +12,8 @@ interface GSMBandConfig extends BandConfig {
  * GSM band configurations
  */
 const GSM_BANDS: Record<GSMBand, GSMBandConfig> = {
+/* These bands are not commonly used in public networks, so they are commented out for now */
+/*
     [GSMBand.GSM_450]: {
         uplinkStart: 450600,    // 450.6 MHz
         uplinkEnd: 457400,      // 457.4 MHz
@@ -48,6 +50,7 @@ const GSM_BANDS: Record<GSMBand, GSMBandConfig> = {
         arfcnEnd: 549,
         channelSpacing: 200     // 0.2 MHz
     },
+*/
     [GSMBand.GSM_850]: {
         uplinkStart: 824200,    // 824.2 MHz
         uplinkEnd: 848800,      // 848.8 MHz

--- a/packages/core/src/radio/types.ts
+++ b/packages/core/src/radio/types.ts
@@ -14,10 +14,11 @@ export enum RadioTechnology {
  * https://downloads.osmocom.org/docs/osmo-bts/master/osmobts-sysmo-vty-reference.pdf
  */
 export enum GSMBand {
-    GSM_450 = 'GSM_450',    // 450 MHz (Doesn't used in public networks)
-    GSM_480 = 'GSM_480',    // 480 MHz (Doesn't used in public networks)
-    GSM_750 = 'GSM_750',    // 750 MHz (Doesn't used in public networks)
-    GSM_810 = 'GSM_810',    // 810 MHz (Doesn't used in public networks)
+/* These bands are not commonly used in public networks, so they are commented out for now */
+    // GSM_450 = 'GSM_450',    // 450 MHz (Doesn't used in public networks)
+    // GSM_480 = 'GSM_480',    // 480 MHz (Doesn't used in public networks)
+    // GSM_750 = 'GSM_750',    // 750 MHz (Doesn't used in public networks)
+    // GSM_810 = 'GSM_810',    // 810 MHz (Doesn't used in public networks)
     GSM_850 = 'GSM_850',    // 850 MHz (Americas)
     GSM_900 = 'GSM_900',    // 900 MHz (Global)
     DCS_1800 = 'DCS_1800',  // 1800 MHz (Global)

--- a/packages/core/src/tests/radio/arfcn.test.ts
+++ b/packages/core/src/tests/radio/arfcn.test.ts
@@ -245,7 +245,7 @@ describe('ARFCN Configuration Functions', () => {
     describe('getSupportedBands', () => {
         it('should return GSM bands for GSM technology', () => {
             const bands = getSupportedBands(RadioTechnology.GSM);
-            expect(bands).toHaveLength(8);
+            expect(bands).toHaveLength(4 /* 8 */);
             expect(bands).toContain('GSM_900');
             expect(bands).toContain('GSM_850');
         });

--- a/packages/core/src/tests/radio/gsm.test.ts
+++ b/packages/core/src/tests/radio/gsm.test.ts
@@ -150,11 +150,12 @@ describe('GSM Functions', () => {
     describe('getAllGSMBands', () => {
         it('should return all GSM bands', () => {
             const bands = getAllGSMBands();
-            expect(bands).toHaveLength(8);
-            expect(bands).toContain('GSM_450');
-            expect(bands).toContain('GSM_480');
-            expect(bands).toContain('GSM_750');
-            expect(bands).toContain('GSM_810');
+            expect(bands).toHaveLength(4 /* 8 */);
+            /* These bands are not commonly used in public networks, so they are commented out for now */
+            // expect(bands).toContain('GSM_450');
+            // expect(bands).toContain('GSM_480');
+            // expect(bands).toContain('GSM_750');
+            // expect(bands).toContain('GSM_810');
             expect(bands).toContain('GSM_850');
             expect(bands).toContain('GSM_900');
             expect(bands).toContain('DCS_1800');

--- a/packages/core/src/tests/radio/types.test.ts
+++ b/packages/core/src/tests/radio/types.test.ts
@@ -35,11 +35,12 @@ describe('Types and Enums', () => {
 
         it('should have all expected GSM bands', () => {
             const bands = Object.values(GSMBand);
-            expect(bands).toHaveLength(8);
-            expect(bands).toContain('GSM_450');
-            expect(bands).toContain('GSM_480');
-            expect(bands).toContain('GSM_750');
-            expect(bands).toContain('GSM_810');
+            expect(bands).toHaveLength(4 /* 8 */);
+            /* These bands are not commonly used in public networks, so they are commented out for now */
+            // expect(bands).toContain('GSM_450');
+            // expect(bands).toContain('GSM_480');
+            // expect(bands).toContain('GSM_750');
+            // expect(bands).toContain('GSM_810');
             expect(bands).toContain('GSM_850');
             expect(bands).toContain('GSM_900');
             expect(bands).toContain('DCS_1800');


### PR DESCRIPTION
- Disable rarely used GSM bands (450/480/750/810) by commenting them out in GSMBand enum and GSM_BANDS config
- Update related tests to reflect the reduced set of supported bands

The uncommon bands are kept in the codebase but disabled for now since they are not typically used in public networks.