### PR TITLE
feat: add monitoring stack (Grafana, Prometheus, InfluxDB) and stats …

### DIFF
--- a/docker/grafana/docker-compose.yml
+++ b/docker/grafana/docker-compose.yml
@@ -1,0 +1,26 @@
+# Notes:
+# - The provisioning directory contains a datasource config that points to Prometheus
+#   at `http://prometheus:9090`. If Prometheus runs outside the same Docker network,
+#   change the URL in `provisioning/datasources/datasource.yml` to e.g. `http://host.docker.internal:9090` or
+#   `http://localhost:9090` depending on your setup.
+# - Default admin credentials are `admin`/`admin` (change in production).
+services:
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    # ports:
+    #   - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: "admin"
+      GF_SECURITY_ADMIN_PASSWORD: "admin"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_DASHBOARDS_MIN_REFRESH_INTERVAL: 1s
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ${GRAFANA_DIR:-.}/provisioning:/etc/grafana/provisioning:ro
+    network_mode: "host"
+
+volumes:
+  grafana-data:
+    driver: local

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: 'osmo-dashboards'
+    orgId: 1
+    folder: 'Osmo'
+    type: file
+    disableDeletion: false
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/grafana/provisioning/dashboards/osmo-bsc.json
+++ b/docker/grafana/provisioning/dashboards/osmo-bsc.json
@@ -1,0 +1,1889 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "BSC Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A",
+          "interval": "1s",
+          "instant": true
+        }
+      ],
+      "title": "Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "uptime{job=\"osmo-bsc\",instance=~\"$instance\"} / 3600",
+          "format": "table",
+          "legendFormat": "uptime_hours",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime (hours)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A",
+          "interval": "1s",
+          "instant": true
+        }
+      ],
+      "title": "Last push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "connectedBts{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "BTS connected",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "btsCount{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "BTS configured",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "omlDown{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "OML down",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Paging_Request_queue_length{job=\"osmo-bsc\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "Paging queue",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 200,
+      "panels": [],
+      "title": "BTS / TRX link health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_BTS_for_this_BSC_where_OML_is_up{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "BTS OML up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_BTS_for_this_BSC_where_RSL_is_up_for_all_TRX{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "BTS RSL fully up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_configured_BTS_for_this_BSC{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "BTS configured (counterpart)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * Number_of_BTS_for_this_BSC_where_RSL_is_up_for_all_TRX{job=\"osmo-bsc\",instance=~\"$instance\"} / clamp_min(Number_of_configured_BTS_for_this_BSC{job=\"osmo-bsc\",instance=~\"$instance\"}, 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "RSL health (BTS %)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_TRX_where_RSL_is_up__total_sum_across_all_BTS{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "TRX RSL up (sum)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_configured_TRX__total_sum_across_all_BTS{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "TRX configured (sum)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Paging & fault indicators",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Paging_Request_queue_length{job=\"osmo-bsc\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "paging_queue",
+          "refId": "A"
+        }
+      ],
+      "title": "Paging queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Number_of_lchans_in_the_BORKEN_state{job=\"osmo-bsc\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "lchans_broken",
+          "refId": "A"
+        },
+        {
+          "expr": "max_over_time(Number_of_timeslots_in_the_BORKEN_state{job=\"osmo-bsc\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "timeslots_broken",
+          "refId": "B"
+        }
+      ],
+      "title": "Broken lchans / timeslots",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Channel utilization (percent used)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * max_over_time(Number_of_TCH_F_channels_used{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_TCH_F_channels_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "TCH/F %",
+          "refId": "A"
+        }
+      ],
+      "title": "TCH/F used (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * max_over_time(Number_of_TCH_H_channels_used{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_TCH_H_channels_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "TCH/H %",
+          "refId": "A"
+        }
+      ],
+      "title": "TCH/H used (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * max_over_time(Number_of_SDCCH8_channels_used{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_SDCCH8_channels_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "SDCCH8 %",
+          "refId": "A"
+        }
+      ],
+      "title": "SDCCH8 used (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * max_over_time(Number_of_CCCH_SDCCH4_channels_used{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_CCCH_SDCCH4_channels_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "CCCH/SDCCH4 %",
+          "refId": "A"
+        }
+      ],
+      "title": "CCCH/SDCCH4 used (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 8,
+        "y": 26
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * max_over_time(Number_of_DYNAMIC_IPACCESS_channels_used{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_DYNAMIC_IPACCESS_channels_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "DYN_IPA %",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * max_over_time(Number_of_DYNAMIC_OSMOCOM_channels_used{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_DYNAMIC_OSMOCOM_channels_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "DYN_OSMO %",
+          "refId": "B"
+        }
+      ],
+      "title": "Dynamic (IPACCESS/OSMOCOM) used (%)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 401,
+      "panels": [],
+      "title": "Runtime (process)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 34
+      },
+      "id": 403,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ],
+      "title": "Resident memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_open_fds{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "osmocom",
+    "osmo-bsc",
+    "radio",
+    "bsc"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({job=\"osmo-bsc\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"osmo-bsc\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": "5s",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Osmocom — BSC (osmo-bsc) Dashboard",
+  "uid": "osmocom-bsc",
+  "version": 2,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/osmo-hlr.json
+++ b/docker/grafana/provisioning/dashboards/osmo-hlr.json
@@ -1,0 +1,644 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "HLR Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "uptime{job=\"osmo-hlr\",instance=~\"$instance\"} / 3600",
+          "format": "table",
+          "legendFormat": "uptime_hours",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime (hours)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Last push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "subscriberCount{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Subscribers",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Runtime (process)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-hlr\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ],
+      "title": "Resident memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_open_fds{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "osmocom",
+    "osmo-hlr",
+    "hlr",
+    "gsup"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({job=\"osmo-hlr\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"osmo-hlr\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": "5s",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Osmocom — HLR (osmo-hlr) Dashboard",
+  "uid": "osmocom-hlr",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/osmo-mgw.json
+++ b/docker/grafana/provisioning/dashboards/osmo-mgw.json
@@ -1,0 +1,1058 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "MGW Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "uptime{job=\"osmo-mgw\",instance=~\"$instance\"} / 3600",
+          "format": "table",
+          "legendFormat": "uptime_hours",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime (hours)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Last push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(connectionCount{job=\"osmo-mgw\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "Connections (reported)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Number_of_endpoints_in_use{job=\"osmo-mgw\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoints in use",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "endpointCount{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoints (reported)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Capacity & utilization",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_endpoints_that_exist_on_the_trunk{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "legendFormat": "endpoints_total",
+          "refId": "A"
+        },
+        {
+          "expr": "max_over_time(Number_of_endpoints_in_use{job=\"osmo-mgw\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "endpoints_in_use",
+          "refId": "B"
+        }
+      ],
+      "title": "Endpoints total vs in use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(connectionCount{job=\"osmo-mgw\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "connections",
+          "refId": "A"
+        }
+      ],
+      "title": "Connections (time series)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * max_over_time(Number_of_endpoints_in_use{job=\"osmo-mgw\",instance=~\"$instance\"}[5s]) / clamp_min(max_over_time(Number_of_endpoints_that_exist_on_the_trunk{job=\"osmo-mgw\",instance=~\"$instance\"}[5s]), 1)",
+          "legendFormat": "endpoints_util_pct",
+          "refId": "A"
+        }
+      ],
+      "title": "Utilization (%)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Runtime (process)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 21
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-mgw\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 21
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ],
+      "title": "Resident memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_open_fds{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "osmocom",
+    "osmo-mgw",
+    "mgw",
+    "rtp"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({job=\"osmo-mgw\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"osmo-mgw\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": "5s",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Osmocom — MGW (osmo-mgw) Dashboard",
+  "uid": "osmocom-mgw",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/osmo-msc.json
+++ b/docker/grafana/provisioning/dashboards/osmo-msc.json
@@ -1,0 +1,2188 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "MSC Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "uptime{job=\"osmo-msc\",instance=~\"$instance\"} / 3600",
+          "format": "table",
+          "legendFormat": "uptime_hours",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime (hours)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time() * 1000 - timestamp{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "legendFormat": "push_age",
+          "refId": "A"
+        }
+      ],
+      "title": "Last push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(activeCalls{job=\"osmo-msc\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "activeCalls",
+          "refId": "A"
+        }
+      ],
+      "title": "Active calls",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(subscriberConnections{job=\"osmo-msc\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "subscriberConnections",
+          "refId": "A"
+        }
+      ],
+      "title": "Subscriber connections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 20,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "smsPerMinute{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "SMS/min",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 22,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "luPerMinute{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "LU/min",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Signaling (SS7/M3UA/SCCP counters as rates)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Total_number_of_packets_received{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "packets_rx/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Total_number_of_packets_transmitted{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "packets_tx/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Packets rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Total_number_of_MSU_received{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MSU_rx/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Total_number_of_MSU_transmitted{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MSU_tx/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Total_number_of_incoming_MSU_discarded{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MSU_discarded/s",
+          "refId": "C"
+        }
+      ],
+      "title": "MSU rate + discarded",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Number_of_packets_received_and_dropped_due_to_Network_Indicator_mismatch{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "NI_mismatch_drop/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Number_of_packets_received_for_unknown_PPID{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "unknown_PPID/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Drops / Unknowns",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Mobility / VLR",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 14,
+        "x": 0,
+        "y": 20
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Received__periodic__Location_Update_requests_{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "LU_periodic/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Successful_Location_Update_procedures_{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "LU_success/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Rejected_Location_Update_requests_{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "LU_reject/s",
+          "refId": "C"
+        }
+      ],
+      "title": "Location Update flow (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 14,
+        "y": 20
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_subscribers_present_in_VLR{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "VLR_subscribers",
+          "refId": "A"
+        },
+        {
+          "expr": "Number_of_PDP_records_present_in_VLR{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "VLR_PDP_records",
+          "refId": "B"
+        }
+      ],
+      "title": "VLR size",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 400,
+      "panels": [],
+      "title": "GSUP",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Received_GSUP_Update_Location_Result_messages{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "UL_result/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Received_GSUP_Update_Location_Error_messages{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "UL_error/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Update Location (result vs error)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Received_GSUP_messages_for_unknown_IMSI{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "unknown_IMSI/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Received_GSUP_message_of_unknown_type{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "unknown_type/s",
+          "refId": "B"
+        }
+      ],
+      "title": "GSUP anomalies",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 500,
+      "panels": [],
+      "title": "SMS / USSD / CM",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 14,
+        "x": 0,
+        "y": 36
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Successful_MT_SMS_delivery_to_subscriber{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MT_SMS_success/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Erroneous_MT_SMS_delivery{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MT_SMS_err/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Failed_MT_SMS_delivery_due_to_paging_timeout__MS_gone__{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MT_SMS_paging_timeout/s",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(Failed_MT_SMS_delivery_due_to_no_memory_on_MS{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MT_SMS_no_memory/s",
+          "refId": "D"
+        }
+      ],
+      "title": "SMS delivery (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 14,
+        "y": 36
+      },
+      "id": 41,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Number_of_SMSs_in_the_in_RAM_pending_delivery_queue{job=\"osmo-msc\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "Pending SMS queue (RAM)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 36
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Currently_active_SS_USSD_sessions{job=\"osmo-msc\",instance=~\"$instance\"}[5s])",
+          "legendFormat": "active_USSD_sessions",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Accepted_CM_Service_Requests_{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "CM_accept/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Rejected_CM_Service_Requests_{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "CM_reject/s",
+          "refId": "C"
+        }
+      ],
+      "title": "USSD + CM service",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 600,
+      "panels": [],
+      "title": "SLS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_0{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 0",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_1{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 1",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_2{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 2",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_3{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 3",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_4{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 4",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_5{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 5",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_6{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 6",
+          "refId": "G"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_7{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 7",
+          "refId": "H"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_8{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 8",
+          "refId": "I"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_9{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 9",
+          "refId": "J"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_10{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 10",
+          "refId": "K"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_11{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 11",
+          "refId": "L"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_12{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 12",
+          "refId": "M"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_13{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 13",
+          "refId": "N"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_14{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 14",
+          "refId": "O"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_15{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 15",
+          "refId": "P"
+        }
+      ],
+      "title": "SLS RX distribution (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_0{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 0",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_1{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 1",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_2{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 2",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_3{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 3",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_4{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 4",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_5{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 5",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_6{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 6",
+          "refId": "G"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_7{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 7",
+          "refId": "H"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_8{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 8",
+          "refId": "I"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_9{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 9",
+          "refId": "J"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_10{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 10",
+          "refId": "K"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_11{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 11",
+          "refId": "L"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_12{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 12",
+          "refId": "M"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_13{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 13",
+          "refId": "N"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_14{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 14",
+          "refId": "O"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_15{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 15",
+          "refId": "P"
+        }
+      ],
+      "title": "SLS TX distribution (rate)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 601,
+      "panels": [],
+      "title": "Runtime (process)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 602,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 603,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ],
+      "title": "Resident memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_open_fds{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "osmocom",
+    "osmo-msc",
+    "radio",
+    "msc"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({job=~\"osmo-msc\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values({job=~\"osmo-msc\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": "5s",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Osmocom — MSC (osmo-msc) Dashboard",
+  "uid": "osmocom-msc",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/osmo-overview.json
+++ b/docker/grafana/provisioning/dashboards/osmo-overview.json
@@ -1,0 +1,2213 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Fleet health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Open STP dashboard",
+              "url": "/d/osmocom-stp?var-job=osmo-stp&var-instance=$instance"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Open STP dashboard",
+          "url": "/d/osmocom-stp?var-job=osmo-stp&var-instance=$instance"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "STP status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Open HLR dashboard",
+              "url": "/d/osmocom-hlr?var-job=osmo-hlr&var-instance=$instance"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 2,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Open HLR dashboard",
+          "url": "/d/osmocom-hlr?var-job=osmo-hlr&var-instance=$instance"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "HLR status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Open MGW dashboard",
+              "url": "/d/osmocom-mgw?var-job=osmo-mgw&var-instance=$instance"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Open MGW dashboard",
+          "url": "/d/osmocom-mgw?var-job=osmo-mgw&var-instance=$instance"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "MGW status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Open MSC dashboard",
+              "url": "/d/osmocom-msc?var-job=osmo-msc&var-instance=$instance"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 4,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Open MSC dashboard",
+          "url": "/d/osmocom-msc?var-job=osmo-msc&var-instance=$instance"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "time()*1000 - timestamp{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "STP push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "HLR push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "MGW push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Open BSC dashboard",
+              "url": "/d/osmocom-bsc?var-job=osmo-bsc&var-instance=$instance"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 5
+      },
+      "id": 9,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Open BSC dashboard",
+          "url": "/d/osmocom-bsc?var-job=osmo-bsc&var-instance=$instance"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "BSC status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 5
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "BSC push age",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Key KPIs (quick glance)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "connectedBts{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        },
+        {
+          "expr": "btsCount{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "B"
+        }
+      ],
+      "title": "BSC: BTS connected / total",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "fields": "",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "connected_total_concat_helper",
+            "binary": {
+              "left": "A",
+              "operator": "+",
+              "right": "B"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "lastNotNull"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 10
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "omlDown{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "BSC: OML down",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 9,
+        "y": 10
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Paging_Request_queue_length{job=\"osmo-bsc\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "BSC: Paging queue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 12,
+        "y": 10
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(activeCalls{job=\"osmo-msc\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC: Active calls",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 15,
+        "y": 10
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(subscriberConnections{job=\"osmo-msc\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC: Subscriber connections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 18,
+        "y": 10
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "smsPerMinute{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC: SMS/min",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 21,
+        "y": 10
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "luPerMinute{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC: LU/min",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 15
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(Number_of_endpoints_in_use{job=\"osmo-mgw\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        },
+        {
+          "expr": "Number_of_endpoints_that_exist_on_the_trunk{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "refId": "B"
+        }
+      ],
+      "title": "MGW: Endpoints in use / total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 15
+      },
+      "id": 41,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max_over_time(connectionCount{job=\"osmo-mgw\",instance=~\"$instance\"}[5s])",
+          "refId": "A"
+        }
+      ],
+      "title": "MGW: Connections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 9,
+        "y": 15
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "subscriberCount{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "HLR: Subscribers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Total_number_of_incoming_MSU_discarded{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "discarded/s",
+          "refId": "A"
+        }
+      ],
+      "title": "MSC signaling: MSU discarded (rate)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 700,
+      "panels": [],
+      "title": "Runtime (Go + processes)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 71,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "go_goroutines{job=\"prometheus\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines prometheus",
+          "refId": "A"
+        },
+        {
+          "expr": "go_goroutines{job=\"osmo-bts\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines osmo-bts",
+          "refId": "B"
+        },
+        {
+          "expr": "go_goroutines{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines osmo-bsc",
+          "refId": "C"
+        },
+        {
+          "expr": "go_goroutines{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines osmo-msc",
+          "refId": "D"
+        },
+        {
+          "expr": "go_goroutines{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines osmo-mgw",
+          "refId": "E"
+        },
+        {
+          "expr": "go_goroutines{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines osmo-hlr",
+          "refId": "F"
+        },
+        {
+          "expr": "go_goroutines{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "legendFormat": "goroutines osmo-stp",
+          "refId": "G"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"prometheus\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"prometheus\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration prometheus",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"osmo-bts\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"osmo-bts\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration osmo-bts",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"osmo-bsc\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"osmo-bsc\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration osmo-bsc",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"osmo-msc\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"osmo-msc\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration osmo-msc",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"osmo-mgw\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"osmo-mgw\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration osmo-mgw",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"osmo-hlr\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"osmo-hlr\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration osmo-hlr",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(go_gc_duration_seconds_sum{job=\"osmo-stp\",instance=~\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"osmo-hlr\",instance=~\"$instance\"}[5m]), 1)",
+          "legendFormat": "gc_mean_duration osmo-stp",
+          "refId": "G"
+        }
+      ],
+      "title": "GC mean duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate prometheus",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-bts\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate osmo-bts",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-bsc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate osmo-bsc",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-msc\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate osmo-msc",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-mgw\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate osmo-mgw",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-hlr\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate osmo-hlr",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu_rate osmo-stp",
+          "refId": "G"
+        }
+      ],
+      "title": "CPU (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"prometheus\",instance=~\"$instance\"}",
+          "legendFormat": "RSS prometheus",
+          "refId": "A"
+        },
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-bts\",instance=~\"$instance\"}",
+          "legendFormat": "RSS osmo-bts",
+          "refId": "B"
+        },
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "legendFormat": "RSS osmo-bsc",
+          "refId": "C"
+        },
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "RSS osmo-msc",
+          "refId": "D"
+        },
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "legendFormat": "RSS osmo-mgw",
+          "refId": "E"
+        },
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "legendFormat": "RSS osmo-hlr",
+          "refId": "F"
+        },
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "legendFormat": "RSS osmo-stp",
+          "refId": "G"
+        }
+      ],
+      "title": "Resident memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_open_fds{job=\"prometheus\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds prometheus",
+          "refId": "A"
+        },
+        {
+          "expr": "process_open_fds{job=\"osmo-bts\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds osmo-bts",
+          "refId": "B"
+        },
+        {
+          "expr": "process_open_fds{job=\"osmo-bsc\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds osmo-bsc",
+          "refId": "C"
+        },
+        {
+          "expr": "process_open_fds{job=\"osmo-msc\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds osmo-msc",
+          "refId": "D"
+        },
+        {
+          "expr": "process_open_fds{job=\"osmo-mgw\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds osmo-mgw",
+          "refId": "E"
+        },
+        {
+          "expr": "process_open_fds{job=\"osmo-hlr\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds osmo-hlr",
+          "refId": "F"
+        },
+        {
+          "expr": "process_open_fds{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds osmo-stp",
+          "refId": "G"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "osmocom",
+    "overview"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({job=~\"osmo-(bts|bsc|msc|mgw|hlr)\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values({job=~\"osmo-(bts|bsc|msc|mgw|hlr)\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": "5s",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Osmocom — Overview (BSC / MSC / MGW / HLR / STP)",
+  "uid": "osmocom-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/osmo-stp.json
+++ b/docker/grafana/provisioning/dashboards/osmo-stp.json
@@ -1,0 +1,1519 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "STP Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "status{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "uptime{job=\"osmo-stp\",instance=~\"$instance\"} / 3600",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime (hours)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 15000
+              },
+              {
+                "color": "red",
+                "value": 60000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "time()*1000 - timestamp{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "instant": true,
+          "interval": "1s",
+          "refId": "A"
+        }
+      ],
+      "title": "Last push age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Total_number_of_MSU_received{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "MSU received",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Total_number_of_MSU_transmitted{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "MSU transmitted",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Total_number_of_incoming_MSU_discarded{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "MSU discarded",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "Number_of_packets_received_for_unknown_PPID{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Unknown PPID",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Packet / MSU rates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Total_number_of_packets_received{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "packets_rx/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Total_number_of_packets_transmitted{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "packets_tx/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Packets RX/TX rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Total_number_of_MSU_received{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MSU_rx/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Total_number_of_MSU_transmitted{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MSU_tx/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Total_number_of_incoming_MSU_discarded{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "MSU_discarded/s",
+          "refId": "C"
+        }
+      ],
+      "title": "MSU RX/TX/discarded rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Drops / anomalies",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Number_of_packets_received_and_dropped_due_to_Network_Indicator_mismatch{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "NI_mismatch_drop/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Number_of_packets_received_for_unknown_PPID{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "unknown_PPID/s",
+          "refId": "B"
+        }
+      ],
+      "title": "NI mismatch / Unknown PPID rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 400,
+      "panels": [],
+      "title": "SLS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "SLS 1"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_0{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 0",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_1{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 1",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_2{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 2",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_3{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 3",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_4{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 4",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_5{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 5",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_6{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 6",
+          "refId": "G"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_7{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 7",
+          "refId": "H"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_8{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 8",
+          "refId": "I"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_9{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 9",
+          "refId": "J"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_10{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 10",
+          "refId": "K"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_11{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 11",
+          "refId": "L"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_12{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 12",
+          "refId": "M"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_13{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 13",
+          "refId": "N"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_14{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 14",
+          "refId": "O"
+        },
+        {
+          "expr": "rate(Number_of_MSU_received_on_SLS_15{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 15",
+          "refId": "P"
+        }
+      ],
+      "title": "SLS RX distribution (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_0{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 0",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_1{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 1",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_2{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 2",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_3{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 3",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_4{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 4",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_5{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 5",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_6{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 6",
+          "refId": "G"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_7{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 7",
+          "refId": "H"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_8{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 8",
+          "refId": "I"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_9{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 9",
+          "refId": "J"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_10{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 10",
+          "refId": "K"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_11{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 11",
+          "refId": "L"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_12{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 12",
+          "refId": "M"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_13{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 13",
+          "refId": "N"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_14{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 14",
+          "refId": "O"
+        },
+        {
+          "expr": "rate(Number_of_MSU_transmitted_on_SLS_15{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "SLS 15",
+          "refId": "P"
+        }
+      ],
+      "title": "SLS TX distribution (rate)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 601,
+      "panels": [],
+      "title": "Runtime (process)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 32
+      },
+      "id": 602,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"osmo-stp\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 32
+      },
+      "id": 603,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ],
+      "title": "Resident memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "process_open_fds{job=\"osmo-stp\",instance=~\"$instance\"}",
+          "legendFormat": "open_fds",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "osmocom",
+    "osmo-stp",
+    "stp",
+    "ss7",
+    "m3ua"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({job=\"osmo-stp\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"osmo-stp\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 5,
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Osmocom — STP (osmo-stp) Dashboard",
+  "uid": "osmocom-stp",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,32 @@
+apiVersion: 1
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+  - name: InfluxDB
+    orgId: 1
+datasources:
+  # Prometheus provisioning template (replace URL if Prometheus runs outside the same Docker network)
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: "1s"
+      minInterval: "1s"
+  # InfluxDB provisioning template (replace placeholders below)
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: false
+    editable: true
+    jsonData:
+      timeInterval: "1s"
+      minInterval: "1s"
+      version: Flux
+      organization: "your-influxdb-org" # Change this to match the organization name you set in InfluxDB
+      defaultBucket: "your-influxdb-bucket" # Change this to match the bucket name you set in InfluxDB
+    secureJsonData:
+      token: "your-influxdb-token" # Change this to match the token you set in InfluxDB

--- a/docker/influxdb/docker-compose.yml
+++ b/docker/influxdb/docker-compose.yml
@@ -1,0 +1,25 @@
+# Usage:
+# from packages/nestjs-microservice/docker run:
+# docker compose -f docker-compose.yml up -d
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    environment:
+      # Initialize InfluxDB on first start. Change these values as needed.
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: "osmoweb" # Change this to your desired username
+      DOCKER_INFLUXDB_INIT_PASSWORD: "osmoweb-password" # Change this to a secure password
+      DOCKER_INFLUXDB_INIT_ORG: "your-influxdb-org" # Change this to your desired organization name
+      DOCKER_INFLUXDB_INIT_BUCKET: "your-influxdb-bucket" # Change this to your desired bucket name
+      DOCKER_INFLUXDB_INIT_RETENTION: 0
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: "your-influxdb-token" # Change this to a secure token
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+
+volumes:
+  influxdb-data:
+    driver: local

--- a/docker/prometheus/alertmanager.yml
+++ b/docker/prometheus/alertmanager.yml
@@ -1,0 +1,20 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: 'email'
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+
+receivers:
+  - name: 'email'
+    email_configs:
+      - to: '{{ .CommonLabels.alert_email | default "you@example.com" }}'
+        from: '{{ .CommonLabels.alert_from | default "alertmanager@example.com" }}'
+        smarthost: '{{ .CommonLabels.smtp_smarthost | default "smtp.example.com:587" }}'
+        auth_username: '{{ .CommonLabels.smtp_auth_username | default "" }}'
+        auth_identity: '{{ .CommonLabels.smtp_auth_identity | default "" }}'
+        auth_password: '{{ .CommonLabels.smtp_auth_password | default "" }}'
+
+inhibit_rules: []

--- a/docker/prometheus/alerts-bsc.yml
+++ b/docker/prometheus/alerts-bsc.yml
@@ -1,0 +1,21 @@
+groups:
+  - name: osmo-bsc.rules
+    rules:
+      - alert: OsmoBSCDown
+        expr: up{job="osmo-bsc"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo BSC down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-bsc (job=\"osmo-bsc\") is down for more than 1 minute."
+
+      # Example custom metric rule; replace `osmo_bsc_metric_errors_total` with a real metric
+      - alert: OsmoBSCHighErrorRate
+        expr: rate(osmo_bsc_metric_errors_total[5m]) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate on Osmo BSC"
+          description: "Error rate above threshold on osmo-bsc for 5 minutes."

--- a/docker/prometheus/alerts-bsc.yml
+++ b/docker/prometheus/alerts-bsc.yml
@@ -1,21 +1,20 @@
 groups:
   - name: osmo-bsc.rules
     rules:
-      - alert: OsmoBSCDown
+      - alert: OsmoBSCPushGatewayDown
         expr: up{job="osmo-bsc"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo BSC Push Gateway down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-bsc (job=\"osmo-bsc\") Push Gateway is down for more than 1 minute."
+
+      - alert: OsmoBSCDown
+        expr: status{job="osmo-bsc"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Osmo BSC down on {{ $labels.instance }}"
           description: "Prometheus target for osmo-bsc (job=\"osmo-bsc\") is down for more than 1 minute."
-
-      # Example custom metric rule; replace `osmo_bsc_metric_errors_total` with a real metric
-      - alert: OsmoBSCHighErrorRate
-        expr: rate(osmo_bsc_metric_errors_total[5m]) > 10
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "High error rate on Osmo BSC"
-          description: "Error rate above threshold on osmo-bsc for 5 minutes."

--- a/docker/prometheus/alerts-hlr.yml
+++ b/docker/prometheus/alerts-hlr.yml
@@ -1,20 +1,20 @@
 groups:
   - name: osmo-hlr.rules
     rules:
-      - alert: OsmoHLRDown
+      - alert: OsmoHLRPushGatewayDown
         expr: up{job="osmo-hlr"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo HLR Push Gateway down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-hlr (job=\"osmo-hlr\") Push Gateway is down for more than 1 minute."
+
+      - alert: OsmoHLRDown
+        expr: status{job="osmo-hlr"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Osmo HLR down on {{ $labels.instance }}"
           description: "Prometheus target for osmo-hlr (job=\"osmo-hlr\") is down for more than 1 minute."
-
-      - alert: OsmoHLRSubscriberDrop
-        expr: rate(osmo_hlr_subscriber_errors_total[5m]) > 5
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Subscriber error rate high on Osmo HLR"
-          description: "Subscriber-related error rate high for osmo-hlr. Replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-hlr.yml
+++ b/docker/prometheus/alerts-hlr.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: osmo-hlr.rules
+    rules:
+      - alert: OsmoHLRDown
+        expr: up{job="osmo-hlr"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo HLR down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-hlr (job=\"osmo-hlr\") is down for more than 1 minute."
+
+      - alert: OsmoHLRSubscriberDrop
+        expr: rate(osmo_hlr_subscriber_errors_total[5m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Subscriber error rate high on Osmo HLR"
+          description: "Subscriber-related error rate high for osmo-hlr. Replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-mgw.yml
+++ b/docker/prometheus/alerts-mgw.yml
@@ -1,20 +1,20 @@
 groups:
   - name: osmo-mgw.rules
     rules:
-      - alert: OsmoMGWDown
+      - alert: OsmoMGWPushGatewayDown
         expr: up{job="osmo-mgw"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo MGW Push Gateway down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-mgw (job=\"osmo-mgw\") Push Gateway is down for more than 1 minute."
+
+      - alert: OsmoMGWDown
+        expr: status{job="osmo-mgw"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Osmo MGW down on {{ $labels.instance }}"
           description: "Prometheus target for osmo-mgw (job=\"osmo-mgw\") is down for more than 1 minute."
-
-      - alert: OsmoMGWHighCallFailures
-        expr: rate(osmo_mgw_call_failures_total[5m]) > 1
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "High call failure rate on Osmo MGW"
-          description: "Call failure rate high for osmo-mgw; replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-mgw.yml
+++ b/docker/prometheus/alerts-mgw.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: osmo-mgw.rules
+    rules:
+      - alert: OsmoMGWDown
+        expr: up{job="osmo-mgw"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo MGW down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-mgw (job=\"osmo-mgw\") is down for more than 1 minute."
+
+      - alert: OsmoMGWHighCallFailures
+        expr: rate(osmo_mgw_call_failures_total[5m]) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High call failure rate on Osmo MGW"
+          description: "Call failure rate high for osmo-mgw; replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-msc.yml
+++ b/docker/prometheus/alerts-msc.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: osmo-msc.rules
+    rules:
+      - alert: OsmoMSCDown
+        expr: up{job="osmo-msc"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo MSC down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-msc (job=\"osmo-msc\") is down for more than 1 minute."
+
+      - alert: OsmoMSCSignallingErrors
+        expr: rate(osmo_msc_signalling_errors_total[5m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High signalling error rate on Osmo MSC"
+          description: "Signalling error rate high for osmo-msc; replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-msc.yml
+++ b/docker/prometheus/alerts-msc.yml
@@ -1,20 +1,20 @@
 groups:
   - name: osmo-msc.rules
     rules:
-      - alert: OsmoMSCDown
+      - alert: OsmoMSCPushGatewayDown
         expr: up{job="osmo-msc"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo MSC Push Gateway down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-msc (job=\"osmo-msc\") Push Gateway is down for more than 1 minute."
+
+      - alert: OsmoMSCDown
+        expr: status{job="osmo-msc"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Osmo MSC down on {{ $labels.instance }}"
           description: "Prometheus target for osmo-msc (job=\"osmo-msc\") is down for more than 1 minute."
-
-      - alert: OsmoMSCSignallingErrors
-        expr: rate(osmo_msc_signalling_errors_total[5m]) > 5
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "High signalling error rate on Osmo MSC"
-          description: "Signalling error rate high for osmo-msc; replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-stp.yml
+++ b/docker/prometheus/alerts-stp.yml
@@ -1,20 +1,20 @@
 groups:
   - name: osmo-stp.rules
     rules:
-      - alert: OsmoSTPDown
+      - alert: OsmoSTPPushGatewayDown
         expr: up{job="osmo-stp"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo STP Push Gateway down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-stp (job=\"osmo-stp\") Push Gateway is down for more than 1 minute."
+
+      - alert: OsmoSTPDown
+        expr: status{job="osmo-stp"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Osmo STP down on {{ $labels.instance }}"
           description: "Prometheus target for osmo-stp (job=\"osmo-stp\") is down for more than 1 minute."
-
-      - alert: OsmoSTPSubscriberDrop
-        expr: rate(osmo_stp_subscriber_errors_total[5m]) > 5
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Subscriber error rate high on Osmo STP"
-          description: "Subscriber-related error rate high for osmo-stp. Replace metric name with actual metric if needed."

--- a/docker/prometheus/alerts-stp.yml
+++ b/docker/prometheus/alerts-stp.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: osmo-stp.rules
+    rules:
+      - alert: OsmoSTPDown
+        expr: up{job="osmo-stp"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Osmo STP down on {{ $labels.instance }}"
+          description: "Prometheus target for osmo-stp (job=\"osmo-stp\") is down for more than 1 minute."
+
+      - alert: OsmoSTPSubscriberDrop
+        expr: rate(osmo_stp_subscriber_errors_total[5m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Subscriber error rate high on Osmo STP"
+          description: "Subscriber-related error rate high for osmo-stp. Replace metric name with actual metric if needed."

--- a/docker/prometheus/docker-compose.yml
+++ b/docker/prometheus/docker-compose.yml
@@ -1,0 +1,46 @@
+# Usage:
+# docker compose -f docker-compose.yml up -d
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ${PROMETHEUS_DIR:-.}/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+
+  pushgateway:
+    image: prom/pushgateway:latest
+    container_name: pushgateway
+    restart: unless-stopped
+    ports:
+      - "9091:9091"
+    volumes:
+      - pushgateway-data:/data
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: alertmanager
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ${PROMETHEUS_DIR:-.}/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+
+volumes:
+  prometheus-data:
+    driver: local
+  pushgateway-data:
+    driver: local
+  alertmanager-data:
+    driver: local
+

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,62 @@
+global:
+  scrape_interval: 1s
+  evaluation_interval: 1s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - ./alerts-bsc.yml
+  - ./alerts-hlr.yml
+  - ./alerts-mgw.yml
+  - ./alerts-msc.yml
+  - ./alerts-stp.yml
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'osmo'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics
+
+  - job_name: 'osmo-bts'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics
+
+  - job_name: 'osmo-bsc'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics
+
+  - job_name: 'osmo-hlr'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics
+
+  - job_name: 'osmo-mgw'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics
+
+  - job_name: 'osmo-msc'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics
+
+  - job_name: 'osmo-stp'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+    metrics_path: /metrics

--- a/docker/start_stats.sh
+++ b/docker/start_stats.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+PROMETHEUS_DIR="./prometheus"
+INFLUXDB_DIR="./influxdb"
+GRAFANA_DIR="./grafana"
+
+cur_dir=$(pwd)
+
+cd ${PROMETHEUS_DIR}
+docker compose -f docker-compose.yml up -d
+cd ${cur_dir}
+
+cd ${INFLUXDB_DIR}
+docker compose -f docker-compose.yml up -d
+cd ${cur_dir}
+
+cd ${GRAFANA_DIR}
+docker compose -f docker-compose.yml up -d
+cd ${cur_dir}
+

--- a/docker/stop_stats.sh
+++ b/docker/stop_stats.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+PROMETHEUS_DIR="./prometheus"
+INFLUXDB_DIR="./influxdb"
+GRAFANA_DIR="./grafana"
+
+cur_dir=$(pwd)
+
+cd ${GRAFANA_DIR}
+docker compose -f docker-compose.yml down
+cd ${cur_dir}
+
+cd ${INFLUXDB_DIR}
+docker compose -f docker-compose.yml down
+cd ${cur_dir}
+
+cd ${PROMETHEUS_DIR}
+docker compose -f docker-compose.yml down
+cd ${cur_dir}

--- a/packages/backend-core/src/osmoctrl/controllers/bsc.controller.ts
+++ b/packages/backend-core/src/osmoctrl/controllers/bsc.controller.ts
@@ -51,22 +51,6 @@ export class BscController extends OsmoBaseController {
         super(host, vtyPort, debug);
     }
 
-    private parseRateCounters(output: string): Record<string, number> {
-        const result: Record<string, number> = {};
-        for (const raw of output.split('\n')) {
-            const line = raw.trim();
-            if (!line) continue;
-            // name: value OR name = value
-            const m = line.match(/^(.+?)[\s:=]+([0-9]+)\s*$/);
-            if (m && m[1] && m[2]) {
-                const name = m[1].trim();
-                const val = parseInt(m[2], 10);
-                if (!isNaN(val)) result[name] = val;
-            }
-        }
-        return result;
-    }
-
     private parseBts(output: string): {
         btsCount: number;
         connectedBts: number;

--- a/packages/backend-core/src/osmoctrl/controllers/mgw.controller.ts
+++ b/packages/backend-core/src/osmoctrl/controllers/mgw.controller.ts
@@ -12,21 +12,6 @@ export class MgwController extends OsmoBaseController {
         super(host, vtyPort, debug);
     }
 
-    private parseRateCounters(output: string): Record<string, number> {
-        const result: Record<string, number> = {};
-        for (const raw of output.split('\n')) {
-            const line = raw.trim();
-            if (!line) continue;
-            const m = line.match(/^(.+?)[\s:=]+([0-9]+)\s*$/);
-            if (m && m[1] && m[2]) {
-                const name = m[1].trim();
-                const val = parseInt(m[2], 10);
-                if (!isNaN(val)) result[name] = val;
-            }
-        }
-        return result;
-    }
-
     // Parse from "mgw trunk ... (virtual-0:common)" block of "show stats"
     private parseEndpointsFromStats(output: string): { endpointCount: number; connectionCount: number } {
         const lines = output.split('\n').map(l => l.trim());

--- a/packages/backend-core/src/osmoctrl/controllers/msc.controller.ts
+++ b/packages/backend-core/src/osmoctrl/controllers/msc.controller.ts
@@ -49,21 +49,6 @@ export class MscController extends OsmoBaseController {
         return rates;
     }
 
-    private parseRateCounters(output: string): Record<string, number> {
-        const result: Record<string, number> = {};
-        for (const raw of output.split('\n')) {
-            const line = raw.trim();
-            if (!line) continue;
-            const m = line.match(/^(.+?)[\s:=]+([0-9]+)\s*(?:\(|$)/);
-            if (m && m[1] && m[2]) {
-                const name = m[1].trim();
-                const val = parseInt(m[2], 10);
-                if (!isNaN(val)) result[name] = val;
-            }
-        }
-        return result;
-    }
-
     private numFrom(output: string, re: RegExp): number {
         const m = output.match(re);
         if (m && m[1]) {

--- a/packages/backend-core/src/osmoctrl/controllers/osmobase.controller.ts
+++ b/packages/backend-core/src/osmoctrl/controllers/osmobase.controller.ts
@@ -2,7 +2,8 @@ import { VtyClient } from '@/osmoctrl/vty.client';
 
 export interface OsmoBaseStats {
     status: 'connected' | 'disconnected';
-    uptime: string;
+    uptime: number; // seconds
+    rateCounters?: Record<string, number>;
 }
 
 export class OsmoBaseController {
@@ -30,8 +31,8 @@ export class OsmoBaseController {
     }
 
     /**
-     * Parse uptime from various osmo-*-vty outputs.
-     * Supports:
+     * Parse uptime from various osmo-*-vty outputs and return a normalized string like "1d 2h 3m 4s".
+     * Examples of supported formats:
      *  - "OsmoBSC has been running for 0d 1h 58m 16s"
      *  - "Uptime: 1d 2h 3m 4s"
      */
@@ -51,22 +52,43 @@ export class OsmoBaseController {
      * Public helper: always read uptime from a VIEW-mode (non-enabled) session.
      * This avoids "% Unknown command." when the main session is in enable/configure.
      */
-    async getUptime(): Promise<string> {
+    async getUptime(): Promise<number> {
         try {
             const { output } = await this._vty.execView('show uptime');
-            return this.parseUptime(output);
-        } catch {
-            return 'n/a';
+            const uptimeStr = this.parseUptime(output);
+            const match = uptimeStr.match(/(\d+)d\s+(\d+)h\s+(\d+)m\s+(\d+)s/);
+            if (match) {
+                const [, days, hours, minutes, seconds] = match.map(Number);
+                const totalSeconds = (((days ?? 0) * 24 + (hours ?? 0)) * 60 + (minutes ?? 0)) * 60 + (seconds ?? 0);
+                return totalSeconds;
+            }
+        } catch { /* ignore */ }
+
+        return 0;
+    }
+
+    protected parseRateCounters(output: string): Record<string, number> {
+        const result: Record<string, number> = {};
+        for (const raw of output.split('\n')) {
+            const line = raw.trim();
+            if (!line) continue;
+            // name: value OR name = value
+            const m = line.match(/^(.+?)[\s:=]+([0-9]+)\s*(?:\(|$)/);
+            if (m && m[1] && m[2]) {
+                const name = m[1].trim();
+                const val = parseInt(m[2], 10);
+                if (!isNaN(val)) result[name] = val;
+            }
         }
+        return result;
     }
 
     async getStats(): Promise<OsmoBaseStats> {
         await this.ensureConnected();
 
-        return {
-            status: this._vty.isConnected ? 'connected' : 'disconnected',
-            uptime: await this.getUptime(),
-        };
+        const uptime = await this.getUptime();
+
+        return { status: this._vty.isConnected ? 'connected' : 'disconnected', uptime };
     }
 
     disconnect(): void {

--- a/packages/backend-core/src/osmoctrl/controllers/stp.controller.ts
+++ b/packages/backend-core/src/osmoctrl/controllers/stp.controller.ts
@@ -1,0 +1,24 @@
+import { OsmoBaseController } from './osmobase.controller';
+import type { OsmoBaseStats } from './osmobase.controller';
+
+export interface StpStats extends OsmoBaseStats {
+    rateCounters: Record<string, number>;
+}
+
+export class StpController extends OsmoBaseController {
+    constructor(host: string = 'localhost', vtyPort: number = 4239, debug: boolean = false) {
+        super(host, vtyPort, debug);
+    }
+
+    async getStats(): Promise<StpStats> {
+        const baseStats = await super.getStats();
+
+        const stats = await this.vty.execChecked('show stats');
+        const rateCounters = this.parseRateCounters(stats.output);
+
+        return {
+            ...baseStats,
+            rateCounters
+        };
+    }
+}

--- a/packages/backend-core/src/osmoctrl/index.ts
+++ b/packages/backend-core/src/osmoctrl/index.ts
@@ -10,8 +10,15 @@ export type { MgwStats } from './controllers/mgw.controller';
 export { MgwController } from './controllers/mgw.controller';
 export type { MscStats } from './controllers/msc.controller';
 export { MscController } from './controllers/msc.controller';
+export type { StpStats } from './controllers/stp.controller';
+export { StpController } from './controllers/stp.controller';
 export { OSMO_COMPONENTS } from './lib/ctrl.types';
 export type {
     CtrlCommand, CtrlResponse, CtrlCommandType, CtrlResponseType,
     CtrlTrapEvent, OsmoComponent
 } from './lib/ctrl.types';
+
+export type { CollectedStat, CollectedStats, StatsWriter } from './stats';
+export {
+    StatsCollector, forEachOsmoService, forEachCollectedStat
+} from './stats';

--- a/packages/backend-core/src/osmoctrl/stats.ts
+++ b/packages/backend-core/src/osmoctrl/stats.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@nestjs/common';
+import { OsmoBaseController } from './controllers/osmobase.controller';
+import type { OsmoBaseStats } from './controllers/osmobase.controller';
+
+export interface CollectedStat {
+    id: string;
+    stats: OsmoBaseStats;
+    timestamp: number;
+}
+
+export type CollectedStats = Array<CollectedStat>;
+
+// Group stats by service (use `id` as service name, fallback to 'osmo') and invoke handler
+export function forEachOsmoService(stats: CollectedStats, handler: (service: string, items: CollectedStats) => void): void {
+    const groups: Record<string, CollectedStats> = {};
+    for (const s of stats) {
+        const service = (s.id || 'osmo').toString();
+        groups[service] = groups[service] || [];
+        groups[service].push(s);
+    }
+
+    for (const service of Object.keys(groups)) {
+        const items = groups[service];
+        if (!items || items.length === 0) continue;
+        handler(service, items);
+    }
+}
+
+export function forEachCollectedStat(stats: CollectedStats, handler: (key: string, value: any) => void): void {
+    for (const s of stats) {
+        // Convert each stat into a Prometheus metric line. For simplicity, we convert all keys to metrics,
+        for (const key of Object.keys(s.stats))
+            handler(key, s.stats[key as keyof typeof s.stats]);
+        // Add rate counters if present
+        if (s.stats.rateCounters) {
+            for (const key of Object.keys(s.stats.rateCounters))
+                handler(key, s.stats.rateCounters[key as keyof typeof s.stats.rateCounters]);
+        }
+        handler('timestamp', s.timestamp); // add timestamp as a separate metric
+    }
+}
+
+export interface StatsWriter {
+    write(stats: CollectedStats): Promise<void>;
+}
+
+export class StatsCollector {
+    protected readonly logger = new Logger(StatsCollector.name);
+    private controllers: { id: string; controller: OsmoBaseController }[] = [];
+
+    addController(id: string, controller: OsmoBaseController) {
+        this.controllers.push({ id, controller });
+    }
+
+    async collect(): Promise<CollectedStats> {
+        const results: CollectedStats = [];
+        const now = Date.now();
+
+        for (const item of this.controllers) {
+            try {
+                await item.controller.connect();
+                const stats = await item.controller.getStats();
+                item.controller.disconnect();
+                this.logger.debug(`Collected stats from controller ${item.id}: count=${Object.keys(stats).length}`);
+                results.push({ id: item.id, stats, timestamp: now });
+            } catch (err) {
+                this.logger.error(`Failed to collect stats from controller ${item.id}: ${(err as Error).message}`);
+                results.push({ id: item.id, stats: { status: 'disconnected', uptime: 0 }, timestamp: now });
+            }
+        }
+
+        return results;
+    }
+}
+
+export default StatsCollector;

--- a/packages/backend-core/src/osmoctrl/vty.client.ts
+++ b/packages/backend-core/src/osmoctrl/vty.client.ts
@@ -195,6 +195,9 @@ export class VtyClient extends EventEmitter {
                 // Ignore any prompt lines until we saw echo or any non-prompt output
                 if (this._promptRegex.test(line)) return;
 
+                // Ignore empty lines while awaiting echo (stale responses from connect \r\n)
+                if (line.trim().length === 0) return;
+
                 // If line equals the echoed command -> switch to collecting output
                 if (line.trim() === this.pending.cmd.trim()) {
                     this.pending.awaitingEcho = false;
@@ -230,9 +233,18 @@ export class VtyClient extends EventEmitter {
 
     async connect(timeoutMs = 5000): Promise<void> {
         return new Promise((resolve, reject) => {
-            const onReady = () => { cleanup(); resolve(); };
-            const onErr = (e: Error) => { cleanup(); reject(e); };
-            const timer = setTimeout(() => { cleanup(); reject(new Error(`VTY connect timeout ${timeoutMs}ms`)); }, timeoutMs);
+            const onReady = () => {
+                cleanup();
+                resolve();
+            };
+            const onErr = (e: Error) => {
+                cleanup();
+                reject(e);
+            };
+            const timer = setTimeout(() => {
+                cleanup();
+                reject(new Error(`VTY connect timeout ${timeoutMs}ms`));
+            }, timeoutMs);
             const cleanup = () => {
                 clearTimeout(timer);
                 this.off('ready', onReady);
@@ -266,16 +278,20 @@ export class VtyClient extends EventEmitter {
      * This does NOT alter the state (enable/configure) of the main session.
      */
     async execView(command: string): Promise<{ output: string }> {
-        const client = new VtyClient(this._host, this._port, this._debug);
-        await client.connect(); // stay in non-enabled VIEW mode
-        try {
-            const res = await client.execChecked(command);
-            return { output: res?.output ?? '' };
-        } finally {
+        return new Promise(async (resolve, reject) => {
+            const client = new VtyClient(this._host, this._port, this._debug);
             try {
-                client.close();
-            } catch { /* ignore */ }
-        }
+                await client.connect(); // stay in non-enabled VIEW mode
+                const res = await client.execChecked(command);
+                resolve({ output: res?.output ?? '' });
+            } catch (err) {
+                reject(new Error(`VTY VIEW command "${command}" failed: ${err}`));
+            } finally {
+                try {
+                    client.close();
+                } catch { /* ignore */ }
+            }
+        });
     }
 
     // Precompiled VTY output error patterns
@@ -352,6 +368,8 @@ export class VtyClient extends EventEmitter {
     }
 
     close() {
-        try { this._socket.end(); } catch { /* ignore */ }
+        try {
+            this._socket.end();
+        } catch { /* ignore */ }
     }
 }

--- a/packages/nestjs-microservice/src/osmo/osmo.module.ts
+++ b/packages/nestjs-microservice/src/osmo/osmo.module.ts
@@ -7,12 +7,13 @@ import { AbisRslGateway } from './gateways/abis-rsl.gateway';
 import { ControlGateway } from './gateways/control.gateway';
 import { MediaGateway } from './gateways/media.gateway';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { StatsModule } from './stats/stats.module';
 import { BtsController } from './controllers/bts.controller';
 import { OSMO_PARAMS } from './tokens';
 import { LoggingModule } from '@websdr/nestjs-microservice/common';
 
 @Module({
-    imports: [ConfigModule, LoggingModule],
+    imports: [ConfigModule, LoggingModule, StatsModule],
     controllers: [BtsController],
     providers: [
         {

--- a/packages/nestjs-microservice/src/osmo/stats/influx.adapter.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/influx.adapter.ts
@@ -1,0 +1,119 @@
+import { Logger } from '@nestjs/common';
+import { forEachOsmoService, forEachCollectedStat } from '@osmoweb/backend-core';
+import type { StatsWriter, CollectedStats } from '@osmoweb/backend-core';
+
+export interface InfluxOptions {
+    url: string; // write endpoint
+    org?: string;
+    bucket?: string;
+    token?: string;
+}
+
+export class InfluxAdapter implements StatsWriter {
+    protected readonly logger = new Logger(InfluxAdapter.name);
+    private opts: InfluxOptions;
+
+    constructor(opts: InfluxOptions) {
+        this.opts = opts;
+        this.logger.log(`Initialized InfluxAdapter with url=${opts.url}`);
+    }
+
+    async write(stats: CollectedStats): Promise<void> {
+        if (!this.opts.url) return;
+
+        // Convert to InfluxDB line-protocol (small, safe subset)
+        const lines: string[] = [];
+        forEachOsmoService(stats, (service, items) => {
+            const tags = `id=${this.escapeTagValue(service)}`;
+            const fieldParts: string[] = [];
+            let tsNs = 0;
+            forEachCollectedStat(items, (key, value) => {
+                if (key === 'timestamp') {
+                    tsNs = Number(value) * 1_000_000; // convert ms to ns for InfluxDB timestamp, and use it as the line timestamp instead of a field
+                    return; // skip timestamp as a field, use it as the line timestamp instead
+                }
+                const field = this.generateMetricString(key, value);
+                if (field) fieldParts.push(field);
+            });
+            if (fieldParts.length === 0) return; // skip if no fields
+            lines.push(`osmo_stats,${tags} ${fieldParts.join(',')} ${tsNs}`);
+        });
+
+        const pushUrl = this.buildWriteUrl(this.opts.url);
+
+        this.logger.debug?.(`Pushing ${lines.length} stats to InfluxDB at ${pushUrl}`);
+
+        try {
+            const res = await fetch(pushUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'text/plain; charset=utf-8',
+                    ...(this.opts.token ? { Authorization: `Token ${this.opts.token}` } : {}),
+                },
+                body: lines.join('\n') + '\n',
+            });
+
+            if (!res.ok) {
+                this.logger.error(`Influx push returned ${res.status} ${res.statusText} for ${this.opts.url}`);
+            }
+        } catch (err) {
+            this.logger.error(`Failed to push metrics to InfluxDB at ${this.opts.url}: ${(err as Error).message ?? err}`);
+            // swallow the error to avoid crashing the whole process
+        }
+    }
+
+    private escapeTagValue(v: any): string {
+        return String(v).replace(/([ ,=])/g, "\\$1");
+    }
+
+    private escapeMetricName(k: string): string {
+        return String(k).replace(/([ ,=])/g, "\\$1");
+    }
+
+    private escapeStringFieldValue(v: string): string {
+        return String(v).replace(/"/g, '\\"');
+    }
+
+    private buildWriteUrl(url: string): string {
+        if (!/\/api(\/|$)/.test(url)) {
+            const baseUrl = url.replace(/\/$/, ''); // remove trailing slash if any
+            if (this.opts.org && this.opts.bucket)
+                return `${baseUrl}/api/v2/write?org=${encodeURIComponent(this.opts.org)}&bucket=${encodeURIComponent(this.opts.bucket)}&precision=ns`;
+            // fallback: at least add the write path with ns precision
+            return `${baseUrl}/api/v2/write?precision=ns`;
+        }
+        return url; // already contains /api/v2/write, use as-is
+    }
+
+    // returns a single field piece like: key=123 or key="str"
+    private generateMetricString(key: string, value: any): string {
+        const k = this.escapeMetricName(key);
+
+        if (key === 'status') {
+            const statusVal = value === 'connected' ? 1 : 0;
+            return `${k}=${statusVal}`;
+        }
+
+        if (k === 'timestamp') {
+            // skip timestamp as a field, use it as the line timestamp instead
+            return '';
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return `${k}=${value}`;
+        }
+
+        if (typeof value === 'boolean') {
+            return `${k}=${value ? 'true' : 'false'}`;
+        }
+
+        if (typeof value === 'string') {
+            const escaped = this.escapeStringFieldValue(String(value ?? ''));
+            return `${k}="${escaped}"`;
+        }
+
+        return ''; // skip unsupported types (objects, arrays, etc.)
+    }
+}
+
+export default InfluxAdapter;

--- a/packages/nestjs-microservice/src/osmo/stats/prometheus.adapter.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/prometheus.adapter.ts
@@ -1,0 +1,101 @@
+import { Logger } from '@nestjs/common';
+import { forEachOsmoService, forEachCollectedStat } from '@osmoweb/backend-core';
+import type { StatsWriter, CollectedStats } from '@osmoweb/backend-core';
+
+export interface PrometheusOptions {
+    // Either a full push URL (including /metrics or /metrics/job/...),
+    // or a base URL like http://pushgateway:9091 — adapter will construct
+    // per-job endpoints: /metrics/job/<job>/instance/<instance>
+    pushGatewayUrl: string;
+}
+
+export class PrometheusAdapter implements StatsWriter {
+    protected readonly logger = new Logger(PrometheusAdapter.name);
+    private opts: PrometheusOptions;
+
+    constructor(opts: PrometheusOptions) {
+        this.opts = opts;
+        this.logger.log(`Initialized PrometheusAdapter with pushGatewayUrl=${opts.pushGatewayUrl}`);
+    }
+
+    async write(stats: CollectedStats): Promise<void> {
+        if (!this.opts.pushGatewayUrl) return;
+        
+        // For each service, POST metrics to Pushgateway under job/instance grouping
+        const promises: Promise<any>[] = [];
+        forEachOsmoService(stats, (service, items) => {
+            this.logger.debug?.(`Preparing stats for service "${service}"`);
+
+            // Build body in exposition format
+            const lines: string[] = [];
+            forEachCollectedStat(items, (key, value) => {
+                const line = this.generateMetricString(key, value);
+                if (line) lines.push(line);
+            });
+            if (lines.length === 0) return; // skip if no metrics to push
+            const pushUrl = this.buildWriteUrl(this.opts.pushGatewayUrl, service);
+
+            this.logger.debug?.(`Pushing ${lines.length} stats to Prometheus Pushgateway at ${pushUrl}`);
+
+            promises.push(
+                fetch(pushUrl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+                    body: lines.join('\n') + '\n',
+                }).catch((err) => {
+                    this.logger.error(`Failed to push metrics to ${pushUrl}: ${(err as Error).message ?? err}`);
+                    return null;
+                })
+            );
+        });
+
+        await Promise.allSettled(promises);
+    }
+
+    private escapeMetricName(k: string): string {
+        // Prometheus metric name rules: [A-Za-z_:][A-Za-z0-9_:]*
+        let name = String(k).replace(/[^A-Za-z0-9_:]/g, '_');
+        if (!/^[A-Za-z_:]/.test(name)) name = '_' + name; // ensure valid first char
+        return name;
+    }
+
+    private escapeStringFieldValue(v: string): string {
+        return String(v).replace(/"/g, '\\"');
+    }
+
+    private buildWriteUrl(url: string, service: string): string {
+        if (!/\/metrics(\/|$)/.test(url) && !/\/job\//.test(url)) {
+            // pushgateway expects /metrics/job/<job>/instance/<instance>. We push aggregated
+            // for the job by omitting instance (use job-only): /metrics/job/<job>
+            const baseUrl = url.replace(/\/$/, '');
+            return `${baseUrl}/metrics/job/${encodeURIComponent(service)}`;
+        }
+        return url; // already contains /metrics or /job/, use as-is
+    }
+
+    // returns a single field piece like: key=123 or key="str"
+    private generateMetricString(key: string, value: any): string {
+        const k = this.escapeMetricName(key);
+        if (k === 'status') {
+            const statusVal = value === 'connected' ? 1 : 0;
+            return `${k} ${statusVal}`;
+        }
+
+        if (k === 'timestamp') {
+            return `${k} ${value}`;
+        }
+
+        if (typeof value === 'number') {
+            return `${k} ${value}`;
+        }
+
+        if (typeof value === 'string') {
+            const sanitizedVal = this.escapeStringFieldValue(value);
+            return `${k}{value="${sanitizedVal}"} 1`;
+        }
+
+        return '';
+    }
+}
+
+export default PrometheusAdapter;

--- a/packages/nestjs-microservice/src/osmo/stats/stats.module.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/stats.module.ts
@@ -1,0 +1,42 @@
+import { Module } from '@nestjs/common';
+import type { Provider } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { StatsService } from './stats.service';
+import { StatsCollector } from '@osmoweb/backend-core';
+import { InfluxAdapter } from './influx.adapter';
+import { PrometheusAdapter } from './prometheus.adapter';
+
+const StatsCollectorProvider: Provider = {
+    provide: StatsCollector,
+    useFactory: () => new StatsCollector(),
+};
+
+const StatsInitProvider: Provider = {
+    provide: 'STATS_INIT',
+    inject: [ConfigService, StatsService],
+    useFactory: (config: ConfigService, statsService: StatsService) => {
+        const influxUrl = config.get<string>('INFLUXDB_URL');
+        if (influxUrl) {
+            const org = config.get<string>('INFLUXDB_ORG');
+            const token = config.get<string>('INFLUXDB_TOKEN');
+            const bucket = config.get<string>('INFLUXDB_BUCKET');
+            statsService.registerWriter(new InfluxAdapter({ url: influxUrl, org, token, bucket }));
+        }
+
+        const promUrl = config.get<string>('PROMETHEUS_PUSH_URL');
+        if (promUrl) {
+            statsService.registerWriter(new PrometheusAdapter({ pushGatewayUrl: promUrl }));
+        }
+
+        return true;
+    },
+};
+
+@Module({
+    imports: [ConfigModule],
+    providers: [StatsCollectorProvider, StatsService, StatsInitProvider],
+    exports: [StatsCollector, StatsService],
+})
+export class StatsModule {}
+
+export default StatsModule;

--- a/packages/nestjs-microservice/src/osmo/stats/stats.service.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/stats.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+    StatsCollector, BscController, HlrController, MgwController,
+    MscController, StpController
+} from '@osmoweb/backend-core';
+import type { CollectedStat, StatsWriter } from '@osmoweb/backend-core';
+import { stringToBoolean } from '@websdr/core/utils'
+
+@Injectable()
+export class StatsService implements OnModuleInit, OnModuleDestroy {
+    protected readonly logger = new Logger(StatsService.name);
+    private intervalHandle: NodeJS.Timeout | null = null;
+    private writers: StatsWriter[] = [];
+
+    constructor(private readonly config: ConfigService, private readonly collector: StatsCollector) {
+        this.logger.log('StatsService initialized');
+    }
+
+    registerWriter(w: StatsWriter) {
+        this.writers.push(w);
+    }
+
+    async onModuleInit() {
+        const rawEnabled = this.config.get<string | boolean | undefined>('STATS_ENABLED') ?? true;
+        const enabled = typeof rawEnabled === 'boolean' ? rawEnabled : stringToBoolean(rawEnabled);
+        const interval = Number(this.config.get<number>('STATS_INTERVAL_MS') ?? 15_000);
+
+        const writerNames = this.writers.map(w => w.constructor.name).join(', ') || 'none';
+        this.logger.log(`StatsService onModuleInit: enabled=${enabled}, interval=${interval}ms, writers=${writerNames}`);
+
+        if (!enabled || this.writers.length === 0) return;
+
+        this.logger.log(`Starting stats polling every ${interval}ms`);
+        this.collector.addController('osmo-bsc', new BscController());
+        this.collector.addController('osmo-hlr', new HlrController());
+        this.collector.addController('osmo-mgw', new MgwController());
+        this.collector.addController('osmo-msc', new MscController());
+        this.collector.addController('osmo-stp', new StpController());
+        this.intervalHandle = setInterval(() => this.collectAndWrite().catch(err => this.logger.error(err)), interval);
+        // run immediately once
+        await this.collectAndWrite();
+    }
+
+    async collectAndWrite() {
+        const stats = await this.collector.collect();
+        await Promise.allSettled(this.writers.map(w => w.write(stats)));
+    }
+
+    async onModuleDestroy() {
+        if (this.intervalHandle) {
+            clearInterval(this.intervalHandle);
+            this.intervalHandle = null;
+        }
+    }
+}
+
+export default StatsService;


### PR DESCRIPTION
…microservice

- Add Docker Compose setup for monitoring infrastructure
- Add Prometheus service and configuration
- Add InfluxDB service for time-series storage
- Add Grafana with provisioning and persistent volume
- Add pre-provisioned dashboards for Osmocom components
- Introduce statistics microservice for collecting and exposing metrics
- Organize monitoring configuration and dashboard files

This introduces a complete monitoring stack and statistics service for collecting, storing and visualizing system metrics.