### PR TITLE
refactor(stats): move stats collectors and adapters to backend-core

### DIFF
--- a/docker/grafana/docker-compose.yml
+++ b/docker/grafana/docker-compose.yml
@@ -1,8 +1,11 @@
 # Notes:
-# - The provisioning directory contains a datasource config that points to Prometheus
-#   at `http://prometheus:9090`. If Prometheus runs outside the same Docker network,
-#   change the URL in `provisioning/datasources/datasource.yml` to e.g. `http://host.docker.internal:9090` or
-#   `http://localhost:9090` depending on your setup.
+# - By default Grafana runs in host network mode (`network_mode: host`). In this mode
+#   the provisioned datasources should point to `http://localhost:9090` (Prometheus)
+#   and `http://localhost:8086` (InfluxDB), because Docker DNS names like `prometheus`
+#   or `influxdb` are not available.
+# - If you switch Grafana to a regular Docker network (and publish ports instead),
+#   you can point Prometheus datasource to `http://prometheus:9090` when Grafana is
+#   attached to the same Docker network as Prometheus.
 # - Default admin credentials are `admin`/`admin` (change in production).
 services:
   grafana:

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -19,7 +19,7 @@ datasources:
   - name: InfluxDB
     type: influxdb
     access: proxy
-    url: http://influxdb:8086
+    url: http://localhost:8086
     isDefault: false
     editable: true
     jsonData:

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -48,6 +48,11 @@
             "types": "./dist/osmorouter/index.d.ts",
             "import": "./dist/osmorouter/index.js",
             "require": "./dist/osmorouter/index.js"
+        },
+        "./osmostats": {
+            "types": "./dist/osmostats/index.d.ts",
+            "import": "./dist/osmostats/index.js",
+            "require": "./dist/osmostats/index.js"
         }
     }
 }

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -2,3 +2,4 @@
 export * from './osmo';
 export * from './osmoctrl';
 export * from './osmorouter';
+export * from './osmostats';

--- a/packages/backend-core/src/osmoctrl/index.ts
+++ b/packages/backend-core/src/osmoctrl/index.ts
@@ -17,8 +17,3 @@ export type {
     CtrlCommand, CtrlResponse, CtrlCommandType, CtrlResponseType,
     CtrlTrapEvent, OsmoComponent
 } from './lib/ctrl.types';
-
-export type { CollectedStat, CollectedStats, StatsWriter } from './stats';
-export {
-    StatsCollector, forEachOsmoService, forEachCollectedStat
-} from './stats';

--- a/packages/backend-core/src/osmostats/adapters/index.ts
+++ b/packages/backend-core/src/osmostats/adapters/index.ts
@@ -1,0 +1,5 @@
+// Re-export osmo controllers functionalities
+export type { InfluxOptions } from './influx.adapter';
+export { default as InfluxAdapter } from './influx.adapter';
+export type { PrometheusOptions } from './prometheus.adapter';
+export { default as PrometheusAdapter } from './prometheus.adapter';

--- a/packages/backend-core/src/osmostats/adapters/influx.adapter.ts
+++ b/packages/backend-core/src/osmostats/adapters/influx.adapter.ts
@@ -1,6 +1,7 @@
-import { Logger } from '@nestjs/common';
-import { forEachOsmoService, forEachCollectedStat } from '@osmoweb/backend-core';
-import type { StatsWriter, CollectedStats } from '@osmoweb/backend-core';
+import { forEachOsmoService, forEachCollectedStat } from '@/osmostats/stats';
+import type { StatsWriter, CollectedStats } from '@/osmostats/stats';
+import type { LoggerInterface } from '@websdr/core/utils';
+import { SimpleLogger } from '@websdr/core/utils';
 
 export interface InfluxOptions {
     url: string; // write endpoint
@@ -10,11 +11,12 @@ export interface InfluxOptions {
 }
 
 export class InfluxAdapter implements StatsWriter {
-    protected readonly logger = new Logger(InfluxAdapter.name);
+    protected readonly logger: LoggerInterface;
     private opts: InfluxOptions;
 
-    constructor(opts: InfluxOptions) {
+    constructor(opts: InfluxOptions, logger?: LoggerInterface) {
         this.opts = opts;
+        this.logger = logger ?? new SimpleLogger(InfluxAdapter.name);
         this.logger.log(`Initialized InfluxAdapter with url=${opts.url}`);
     }
 

--- a/packages/backend-core/src/osmostats/adapters/prometheus.adapter.ts
+++ b/packages/backend-core/src/osmostats/adapters/prometheus.adapter.ts
@@ -1,6 +1,7 @@
-import { Logger } from '@nestjs/common';
-import { forEachOsmoService, forEachCollectedStat } from '@osmoweb/backend-core';
-import type { StatsWriter, CollectedStats } from '@osmoweb/backend-core';
+import { forEachOsmoService, forEachCollectedStat } from '@/osmostats/stats';
+import type { StatsWriter, CollectedStats } from '@/osmostats/stats';
+import type { LoggerInterface } from '@websdr/core/utils';
+import { SimpleLogger } from '@websdr/core/utils';
 
 export interface PrometheusOptions {
     // Either a full push URL (including /metrics or /metrics/job/...),
@@ -10,11 +11,12 @@ export interface PrometheusOptions {
 }
 
 export class PrometheusAdapter implements StatsWriter {
-    protected readonly logger = new Logger(PrometheusAdapter.name);
+    protected readonly logger: LoggerInterface;
     private opts: PrometheusOptions;
 
-    constructor(opts: PrometheusOptions) {
+    constructor(opts: PrometheusOptions, logger?: LoggerInterface) {
         this.opts = opts;
+        this.logger = logger ?? new SimpleLogger(PrometheusAdapter.name);
         this.logger.log(`Initialized PrometheusAdapter with pushGatewayUrl=${opts.pushGatewayUrl}`);
     }
 

--- a/packages/backend-core/src/osmostats/index.ts
+++ b/packages/backend-core/src/osmostats/index.ts
@@ -1,0 +1,6 @@
+// Re-export osmo controllers functionalities
+export * from './adapters';
+export type { CollectedStat, CollectedStats, StatsWriter } from './stats';
+export {
+    StatsCollector, forEachOsmoService, forEachCollectedStat
+} from './stats';

--- a/packages/backend-core/src/osmostats/stats.ts
+++ b/packages/backend-core/src/osmostats/stats.ts
@@ -1,6 +1,7 @@
-import { Logger } from '@nestjs/common';
-import { OsmoBaseController } from './controllers/osmobase.controller';
-import type { OsmoBaseStats } from './controllers/osmobase.controller';
+import { OsmoBaseController } from '@/osmoctrl/controllers/osmobase.controller';
+import type { OsmoBaseStats } from '@/osmoctrl/controllers/osmobase.controller';
+import type { LoggerInterface } from '@websdr/core/utils';
+import { SimpleLogger } from '@websdr/core/utils';
 
 export interface CollectedStat {
     id: string;
@@ -45,8 +46,13 @@ export interface StatsWriter {
 }
 
 export class StatsCollector {
-    protected readonly logger = new Logger(StatsCollector.name);
+    protected readonly logger: LoggerInterface;
     private controllers: { id: string; controller: OsmoBaseController }[] = [];
+
+    constructor(logger?: LoggerInterface) {
+        this.logger = logger ?? new SimpleLogger(StatsCollector.name);
+        this.logger.log('StatsCollector initialized');
+    }
 
     addController(id: string, controller: OsmoBaseController) {
         this.controllers.push({ id, controller });
@@ -61,7 +67,7 @@ export class StatsCollector {
                 await item.controller.connect();
                 const stats = await item.controller.getStats();
                 item.controller.disconnect();
-                this.logger.debug(`Collected stats from controller ${item.id}: count=${Object.keys(stats).length}`);
+                this.logger.debug?.(`Collected stats from controller ${item.id}: count=${Object.keys(stats).length}`);
                 results.push({ id: item.id, stats, timestamp: now });
             } catch (err) {
                 this.logger.error(`Failed to collect stats from controller ${item.id}: ${(err as Error).message}`);

--- a/packages/nestjs-microservice/package.json
+++ b/packages/nestjs-microservice/package.json
@@ -49,20 +49,10 @@
             "import": "./dist/index.js",
             "require": "./dist/index.js"
         },
-        "./auth": {
-            "types": "./dist/auth/index.d.ts",
-            "import": "./dist/auth/index.js",
-            "require": "./dist/auth/index.js"
-        },
         "./osmo": {
             "types": "./dist/osmo/index.d.ts",
             "import": "./dist/osmo/index.js",
             "require": "./dist/osmo/index.js"
-        },
-        "./users": {
-            "types": "./dist/users/index.d.ts",
-            "import": "./dist/users/index.js",
-            "require": "./dist/users/index.js"
         }
     }
 }

--- a/packages/nestjs-microservice/src/osmo/stats/stats.module.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/stats.module.ts
@@ -1,42 +1,10 @@
 import { Module } from '@nestjs/common';
-import type { Provider } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { StatsService } from './stats.service';
-import { StatsCollector } from '@osmoweb/backend-core';
-import { InfluxAdapter } from './influx.adapter';
-import { PrometheusAdapter } from './prometheus.adapter';
-
-const StatsCollectorProvider: Provider = {
-    provide: StatsCollector,
-    useFactory: () => new StatsCollector(),
-};
-
-const StatsInitProvider: Provider = {
-    provide: 'STATS_INIT',
-    inject: [ConfigService, StatsService],
-    useFactory: (config: ConfigService, statsService: StatsService) => {
-        const influxUrl = config.get<string>('INFLUXDB_URL');
-        if (influxUrl) {
-            const org = config.get<string>('INFLUXDB_ORG');
-            const token = config.get<string>('INFLUXDB_TOKEN');
-            const bucket = config.get<string>('INFLUXDB_BUCKET');
-            statsService.registerWriter(new InfluxAdapter({ url: influxUrl, org, token, bucket }));
-        }
-
-        const promUrl = config.get<string>('PROMETHEUS_PUSH_URL');
-        if (promUrl) {
-            statsService.registerWriter(new PrometheusAdapter({ pushGatewayUrl: promUrl }));
-        }
-
-        return true;
-    },
-};
+import { ConfigModule } from '@nestjs/config';
+import { osmoStatsProviders } from './stats.providers';
+import { LoggingModule } from '@websdr/nestjs-microservice/common';
 
 @Module({
-    imports: [ConfigModule],
-    providers: [StatsCollectorProvider, StatsService, StatsInitProvider],
-    exports: [StatsCollector, StatsService],
+    imports: [ConfigModule, LoggingModule],
+    providers: [...osmoStatsProviders],
 })
 export class StatsModule {}
-
-export default StatsModule;

--- a/packages/nestjs-microservice/src/osmo/stats/stats.providers.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/stats.providers.ts
@@ -1,0 +1,48 @@
+import type { LoggerService, Provider } from '@nestjs/common';
+import {
+    StatsCollector, InfluxAdapter, PrometheusAdapter
+} from '@osmoweb/backend-core/osmostats';
+import { ConfigService } from '@nestjs/config';
+import { StatsService } from './stats.service';
+import { LOGGER, createContextLogger } from '@websdr/nestjs-microservice/common'
+
+export const osmoStatsProviders: Provider[] = [
+    {
+        inject: [LOGGER],
+        provide: StatsCollector,
+        useFactory: (logger: LoggerService) => {
+            const ctxLogger = createContextLogger(logger, 'StatsCollector');
+            return new StatsCollector(ctxLogger);
+        },
+    },
+    {
+        inject: [ConfigService, StatsCollector, LOGGER],
+        provide: StatsService,
+        useFactory: (config: ConfigService, collector: StatsCollector, logger: LoggerService) => {
+            const ctxLogger = createContextLogger(logger, 'StatsService');
+            return new StatsService(config, collector, ctxLogger);
+        },
+    },
+    {
+        inject: [ConfigService, StatsService, LOGGER],
+        provide: 'STATS_INIT',
+        useFactory: (config: ConfigService, statsService: StatsService, logger: LoggerService) => {
+            const influxUrl = config.get<string>('INFLUXDB_URL');
+            if (influxUrl) {
+                const ctxLogger = createContextLogger(logger, 'InfluxAdapter');
+                const org = config.get<string>('INFLUXDB_ORG');
+                const token = config.get<string>('INFLUXDB_TOKEN');
+                const bucket = config.get<string>('INFLUXDB_BUCKET');
+                statsService.registerWriter(new InfluxAdapter({ url: influxUrl, org, token, bucket }, ctxLogger));
+            }
+
+            const promUrl = config.get<string>('PROMETHEUS_PUSH_URL');
+            if (promUrl) {
+                const ctxLogger = createContextLogger(logger, 'PrometheusAdapter');
+                statsService.registerWriter(new PrometheusAdapter({ pushGatewayUrl: promUrl }, ctxLogger));
+            }
+
+            return true;
+        }
+    },
+];

--- a/packages/nestjs-microservice/src/osmo/stats/stats.service.ts
+++ b/packages/nestjs-microservice/src/osmo/stats/stats.service.ts
@@ -1,20 +1,23 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import type { OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
     StatsCollector, BscController, HlrController, MgwController,
     MscController, StpController
 } from '@osmoweb/backend-core';
-import type { CollectedStat, StatsWriter } from '@osmoweb/backend-core';
+import type { StatsWriter } from '@osmoweb/backend-core';
 import { stringToBoolean } from '@websdr/core/utils'
+import type { LoggerInterface } from '@websdr/core/utils';
+import { SimpleLogger } from '@websdr/core/utils';
 
 @Injectable()
 export class StatsService implements OnModuleInit, OnModuleDestroy {
-    protected readonly logger = new Logger(StatsService.name);
+    protected readonly logger: LoggerInterface;
     private intervalHandle: NodeJS.Timeout | null = null;
     private writers: StatsWriter[] = [];
 
-    constructor(private readonly config: ConfigService, private readonly collector: StatsCollector) {
+    constructor(private readonly config: ConfigService, private readonly collector: StatsCollector, logger?: LoggerInterface) {
+        this.logger = logger ?? new SimpleLogger(StatsService.name);
         this.logger.log('StatsService initialized');
     }
 
@@ -25,7 +28,7 @@ export class StatsService implements OnModuleInit, OnModuleDestroy {
     async onModuleInit() {
         const rawEnabled = this.config.get<string | boolean | undefined>('STATS_ENABLED') ?? true;
         const enabled = typeof rawEnabled === 'boolean' ? rawEnabled : stringToBoolean(rawEnabled);
-        const interval = Number(this.config.get<number>('STATS_INTERVAL_MS') ?? 15_000);
+        const interval = Number(this.config.get<number>('STATS_INTERVAL_MS') ?? 10_000);
 
         const writerNames = this.writers.map(w => w.constructor.name).join(', ') || 'none';
         this.logger.log(`StatsService onModuleInit: enabled=${enabled}, interval=${interval}ms, writers=${writerNames}`);

--- a/packages/vue3-components/package.json
+++ b/packages/vue3-components/package.json
@@ -32,6 +32,7 @@
     "dependencies": {
         "@osmoweb/core": "^0.5.0",
         "@osmoweb/frontend-core": "^0.5.0",
+        "@websdr/vue3-components": "^0.5.3",
         "vue": "^3.5.29"
     },
     "devDependencies": {
@@ -39,7 +40,6 @@
         "@vue/cli-plugin-typescript": "^5.0.9",
         "@vue/cli-service": "^5.0.9",
         "@vue/test-utils": "^2.4.6",
-        "@websdr/vue3-components": "^0.5.3",
         "happy-dom": "^20.8.3",
         "sass": "^1.97.3",
         "vue-tsc": "^3.2.5"

--- a/packages/vue3-components/src/components/BtsInput.vue
+++ b/packages/vue3-components/src/components/BtsInput.vue
@@ -125,7 +125,7 @@ const handleCancel = (closeDropdown: () => void) => {
             </div>
         </template>
         <template #content="{ close }">
-            <BtsConfig :bts="btsConfig" :supported-technologies="supportedTechnologies" :searchable="props.searchable"
+            <BtsConfig :bts="btsConfig" :supported-technologies="props.supportedTechnologies" :searchable="props.searchable"
                 @submit="(config) => handleSubmit(close, config)" @cancel="() => handleCancel(close)" />
         </template>
     </Dropdown>

--- a/packages/vue3-components/src/components/index.ts
+++ b/packages/vue3-components/src/components/index.ts
@@ -1,3 +1,5 @@
 // Re-export all Vue 3 components
 export { default as BtsInput } from './BtsInput.vue';
 export type { BtsInputProps, BtsParams } from './BtsInput.vue';
+export { default as BtsConfig } from './BtsConfig.vue';
+export type { BtsConfigProps } from './BtsConfig.vue';


### PR DESCRIPTION
- Extract stats subsystem (StatsCollector, adapters, helpers) from nestjs-microservice into backend-core under new `osmostats` module
- Add Prometheus and InfluxDB adapters to backend-core