### PR TITLE
refactor: reuse shared WebSocket API URL helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,13 +2285,13 @@
             }
         },
         "node_modules/@tanstack/react-virtual": {
-            "version": "3.13.26",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.26.tgz",
-            "integrity": "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+            "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tanstack/virtual-core": "3.16.0"
+                "@tanstack/virtual-core": "3.17.0"
             },
             "funding": {
                 "type": "github",
@@ -2303,9 +2303,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.16.0.tgz",
-            "integrity": "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+            "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -3925,28 +3925,28 @@
             }
         },
         "node_modules/@websdr/core": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@websdr/core/-/core-0.6.0.tgz",
-            "integrity": "sha512-PRE9bKxTr9B1NQseEqoyjDTYJTxRHjkGQq9qgC0+mmVl3OznafcXBo6+m/qUzl2yVaiqfbySJz9fVR+/if7u5A==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@websdr/core/-/core-0.6.1.tgz",
+            "integrity": "sha512-hFppJms/AFVvUe0KfxmgcecpHH/DyqGPEk3QHkoNBrG3La94HcLgvtWB9dCU3rGUTrxGCuk/nCKVKtpm+9agsQ==",
             "license": "MIT"
         },
         "node_modules/@websdr/frontend-core": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@websdr/frontend-core/-/frontend-core-0.6.0.tgz",
-            "integrity": "sha512-KsqRhlxWpYaoFPX9sLnuMwjobf9cDSTralDULWhLsuGTyXh6O8cVLhaIDAwU1lGqNvgkhG5nJVQAJFt/5BKbjw==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@websdr/frontend-core/-/frontend-core-0.6.1.tgz",
+            "integrity": "sha512-3G6ZA9HscUmM6SVAAN+w02BD+G9qUq08nV+66kQSPlyubJZPPwDZ/8xHBIbCXTY035WAjKQv1SmZvWwcQiWyjA==",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.0",
+                "@websdr/core": "^0.6.1",
                 "usb": "^2.17.0"
             }
         },
         "node_modules/@websdr/nestjs-microservice": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@websdr/nestjs-microservice/-/nestjs-microservice-0.6.0.tgz",
-            "integrity": "sha512-G0GgYhEotz77RwGhGmIFhtuD09+TVmtECu8/MMK3M6S8IZwmTaqsfuIs7ZId7QAH5RzO9DdjAPouNMPUF420lg==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@websdr/nestjs-microservice/-/nestjs-microservice-0.6.1.tgz",
+            "integrity": "sha512-YQs9Elgvsco0OOljWQZ+chDGo3VpTEaw+JxOJSdwarbc090/kScWh0ogL1dYVARSGQrNGW6/7NcAjMpqp0Fp+Q==",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.0",
+                "@websdr/core": "^0.6.1",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.15.1",
                 "passport-jwt": "^4.0.1",
@@ -3963,13 +3963,13 @@
             }
         },
         "node_modules/@websdr/vue3-components": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@websdr/vue3-components/-/vue3-components-0.6.0.tgz",
-            "integrity": "sha512-6cK4U+ZcSvkAC8w0jT3rzyqwKgMtqVLHX+VeDG0OAlm1UQoV9rCEk5Vzsl7miyY++T3RHL5qBR9d6XTIOc6rVw==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@websdr/vue3-components/-/vue3-components-0.6.1.tgz",
+            "integrity": "sha512-uWvZ9rjJmlG5HlBk9ECxgdJZHxxpmoRW8NlPf/CLsSKsDNB+C+VOYkLsLQXtdf/nH7dU397hbso/6AhCrhce7g==",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.0",
-                "@websdr/frontend-core": "^0.6.0"
+                "@websdr/core": "^0.6.1",
+                "@websdr/frontend-core": "^0.6.1"
             },
             "peerDependencies": {
                 "vue": "^3.5.0"
@@ -3990,9 +3990,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@zenuml/core": {
-            "version": "3.49.0",
-            "resolved": "https://registry.npmjs.org/@zenuml/core/-/core-3.49.0.tgz",
-            "integrity": "sha512-15hZEYfZYtuJXYK3JVR7cwy95uRfLYn+nlJgJOALDM6Q/xsRqpP+npHoBnfQ3ZmERFjn71Icwuh5B7I3FR6vPA==",
+            "version": "3.49.2",
+            "resolved": "https://registry.npmjs.org/@zenuml/core/-/core-3.49.2.tgz",
+            "integrity": "sha512-qeQMapuE0XETML2mRw2MIIrMCjcZBhRDSwW10//q8XQ+VyExzkAn39VCBwxIbbPdTBt6gJnaBBixF9A4hsIxcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4027,7 +4027,7 @@
                 "@napi-rs/canvas": "^0.1.97"
             },
             "peerDependencies": {
-                "playwright-core": "^1.59.1"
+                "playwright-core": "1.57.0"
             },
             "peerDependenciesMeta": {
                 "playwright-core": {
@@ -4549,9 +4549,9 @@
             "license": "MIT"
         },
         "node_modules/bare-events": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
-            "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+            "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -4565,9 +4565,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+            "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -4641,9 +4641,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.4.tgz",
+            "integrity": "sha512-zbQJi2YQUe3SrX19TItQ8DoPj9E1i5rrdE9iHV4PhUif1GodNRSe85lavVGbmU7P4M8579EQi4akGFuhCATWaQ==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -4964,6 +4964,19 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/buffer-image-size": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+            "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
         },
         "node_modules/bytes": {
             "version": "3.1.2",
@@ -6051,9 +6064,9 @@
             "license": "MIT"
         },
         "node_modules/cytoscape": {
-            "version": "3.33.4",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
-            "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+            "version": "3.34.0",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+            "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7000,9 +7013,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-            "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+            "version": "3.4.8",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+            "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
             "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
@@ -7188,9 +7201,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.364",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
-            "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+            "version": "1.5.367",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz",
+            "integrity": "sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -7239,9 +7252,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.22.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-            "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+            "version": "5.22.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
+            "integrity": "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8496,15 +8509,16 @@
             "license": "MIT"
         },
         "node_modules/happy-dom": {
-            "version": "20.9.0",
-            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
-            "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+            "version": "20.10.1",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.1.tgz",
+            "integrity": "sha512-awPoqPjx8CgjapJllyDlgzgVHjBExcitKK5ZJkxwhQJyQpHFkyS2bEcqCm7IeW20cQvuCI0cz2Ifq79CJKqtiw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": ">=20.0.0",
                 "@types/whatwg-mimetype": "^3.0.2",
                 "@types/ws": "^8.18.1",
+                "buffer-image-size": "^0.6.4",
                 "entities": "^7.0.1",
                 "whatwg-mimetype": "^3.0.0",
                 "ws": "^8.18.3"
@@ -9714,9 +9728,9 @@
             "license": "MIT"
         },
         "node_modules/libphonenumber-js": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.4.tgz",
-            "integrity": "sha512-/lhWr7vq8foWN9Apksnd9v8/cfwzW6g6qKOCo25XBGkNaVCHucXO57hLy4CWHGvytvLz6Nt3J5Gs8p3jlCGFXA==",
+            "version": "1.13.5",
+            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.5.tgz",
+            "integrity": "sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A==",
             "license": "MIT"
         },
         "node_modules/lightningcss": {
@@ -10929,9 +10943,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.46",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "version": "2.0.47",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12849,9 +12863,9 @@
             }
         },
         "node_modules/react": {
-            "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-            "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12881,16 +12895,16 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-            "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.6"
+                "react": "^19.2.7"
             }
         },
         "node_modules/react-stately": {
@@ -16153,11 +16167,11 @@
         },
         "packages/backend-core": {
             "name": "@osmoweb/backend-core",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/core": "^0.6.2",
-                "@websdr/core": "^0.6.0",
+                "@osmoweb/core": "^0.6.3",
+                "@websdr/core": "^0.6.1",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -16167,10 +16181,10 @@
         },
         "packages/core": {
             "name": "@osmoweb/core",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.0"
+                "@websdr/core": "^0.6.1"
             },
             "devDependencies": {
                 "@types/node": "^25.6.0"
@@ -16178,13 +16192,13 @@
         },
         "packages/frontend-core": {
             "name": "@osmoweb/frontend-core",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/backend-core": "^0.6.2",
-                "@osmoweb/core": "^0.6.2",
-                "@websdr/core": "^0.6.0",
-                "@websdr/frontend-core": "^0.6.0"
+                "@osmoweb/backend-core": "^0.6.3",
+                "@osmoweb/core": "^0.6.3",
+                "@websdr/core": "^0.6.1",
+                "@websdr/frontend-core": "^0.6.1"
             },
             "devDependencies": {
                 "@types/emscripten": "^1.41.5"
@@ -16192,12 +16206,12 @@
         },
         "packages/nestjs-microservice": {
             "name": "@osmoweb/nestjs-microservice",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/backend-core": "^0.6.2",
-                "@osmoweb/core": "^0.6.2",
-                "@websdr/nestjs-microservice": "^0.6.0",
+                "@osmoweb/backend-core": "^0.6.3",
+                "@osmoweb/core": "^0.6.3",
+                "@websdr/nestjs-microservice": "^0.6.1",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.15.1",
                 "passport-jwt": "^4.0.1",
@@ -16220,12 +16234,12 @@
         },
         "packages/vue3-components": {
             "name": "@osmoweb/vue3-components",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/core": "^0.6.2",
-                "@osmoweb/frontend-core": "^0.6.2",
-                "@websdr/vue3-components": "^0.6.0"
+                "@osmoweb/core": "^0.6.3",
+                "@osmoweb/frontend-core": "^0.6.3",
+                "@websdr/vue3-components": "^0.6.1"
             },
             "devDependencies": {
                 "@vitejs/plugin-vue": "^6.0.7",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/backend-core",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "This is the core backend package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -24,8 +24,8 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/core": "^0.6.2",
-        "@websdr/core": "^0.6.0",
+        "@osmoweb/core": "^0.6.3",
+        "@websdr/core": "^0.6.1",
         "ws": "^8.21.0"
     },
     "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/core",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "This is the core package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -30,7 +30,7 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@websdr/core": "^0.6.0"
+        "@websdr/core": "^0.6.1"
     },
     "devDependencies": {
         "@types/node": "^25.6.0"

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/frontend-core",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "This is the core frontend package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -25,10 +25,10 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/core": "^0.6.2",
-        "@osmoweb/backend-core": "^0.6.2",
-        "@websdr/core": "^0.6.0",
-        "@websdr/frontend-core": "^0.6.0"
+        "@osmoweb/core": "^0.6.3",
+        "@osmoweb/backend-core": "^0.6.3",
+        "@websdr/core": "^0.6.1",
+        "@websdr/frontend-core": "^0.6.1"
     },
     "devDependencies": {
         "@types/emscripten": "^1.41.5"

--- a/packages/frontend-core/src/osmo/osmoWsUrl.ts
+++ b/packages/frontend-core/src/osmo/osmoWsUrl.ts
@@ -1,14 +1,14 @@
 import { getEnvValue } from '@websdr/frontend-core/common';
-import { getApiBase } from '@websdr/frontend-core/services';
+import { apiWsUrl } from '@websdr/frontend-core/services';
 
 type OsmoEnv = {
     VITE_OSMO_PORT?: string;
     OSMO_PORT?: string;
 };
 
-function getEnvOsmoPort(): string | undefined {
+function getEnvOsmoPort(): number | undefined {
     const envOsmoPort = getEnvValue<OsmoEnv>(["VITE_OSMO_PORT", "OSMO_PORT"]);
-    return envOsmoPort === undefined ? undefined : String(envOsmoPort);
+    return envOsmoPort === undefined ? undefined : Number(envOsmoPort);
 }
 
 export function endpointToOsmoWsUrl(endpoint: string): string {
@@ -16,13 +16,8 @@ export function endpointToOsmoWsUrl(endpoint: string): string {
     if (!endpoint) return ret;
     if (endpoint.startsWith('ws://') || endpoint.startsWith('wss://'))
         ret = endpoint;
-    else {
-        const locUrl = new URL(getApiBase());
-        if (locUrl.protocol === "https:") locUrl.protocol = "wss:";
-        else locUrl.protocol = "ws:";
-        locUrl.port = getEnvOsmoPort() ?? locUrl.port;
-        locUrl.pathname = endpoint;
-        ret = locUrl.toString();
-    }
+    else
+        ret = apiWsUrl(endpoint, getEnvOsmoPort());
+
     return ret;
 }

--- a/packages/nestjs-microservice/package.json
+++ b/packages/nestjs-microservice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/nestjs-microservice",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "This is a NestJS microservice for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -25,9 +25,9 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/backend-core": "^0.6.2",
-        "@osmoweb/core": "^0.6.2",
-        "@websdr/nestjs-microservice": "^0.6.0",
+        "@osmoweb/backend-core": "^0.6.3",
+        "@osmoweb/core": "^0.6.3",
+        "@websdr/nestjs-microservice": "^0.6.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "passport-jwt": "^4.0.1",

--- a/packages/vue3-components/package.json
+++ b/packages/vue3-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/vue3-components",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "This is a Vue 3 components package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -32,9 +32,9 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/core": "^0.6.2",
-        "@osmoweb/frontend-core": "^0.6.2",
-        "@websdr/vue3-components": "^0.6.0"
+        "@osmoweb/core": "^0.6.3",
+        "@osmoweb/frontend-core": "^0.6.3",
+        "@websdr/vue3-components": "^0.6.1"
     },
     "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.7",

--- a/test-apps/package.json
+++ b/test-apps/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/test-apps",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "OsmoWeb package test applications",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",


### PR DESCRIPTION
Replace manual WebSocket URL construction in osmoWsUrl with apiWsUrl() and normalize OSMO_PORT environment handling to numeric values.

Bump package patch versions across the monorepo for the shared API update.