### PR TITLE
chore: bump OsmoWeb packages to 0.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4179,28 +4179,28 @@
             }
         },
         "node_modules/@websdr/core": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@websdr/core/-/core-0.6.3.tgz",
-            "integrity": "sha512-YGs2B6wWDqafJh0J0HnFEbaaZu4ayfaZnjvDGtiMvOzcfCarJVaSdv8URk//O3fbutyiA2y22gJcJBgL8iaVuQ==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@websdr/core/-/core-0.6.4.tgz",
+            "integrity": "sha512-ECKMYklrkfN3k1LzGvVhUHBdep1vK5ANEF+CgCbCrCpSbfJYASl+hKLmlmN8E5RvOhlWHn0STBXqkzkDDpd8Cg==",
             "license": "MIT"
         },
         "node_modules/@websdr/frontend-core": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@websdr/frontend-core/-/frontend-core-0.6.3.tgz",
-            "integrity": "sha512-DvOlT5JDBPFPEUp93Rsjw98oITTt8PdqcNJX07W+D30BRVaZzIRFl9fV8d5w5M9J39rQov1QCTQe5/1Yv82HmA==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@websdr/frontend-core/-/frontend-core-0.6.4.tgz",
+            "integrity": "sha512-ggBD0nvlJGtzclmMQ4ZToSqhCUHfTh/RfGvK060fdw32q/7yE3pQxymSeX+uGCJECdL45GP7cEHdNj4J/EIVpQ==",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.3",
+                "@websdr/core": "^0.6.4",
                 "usb": "^3.0.1"
             }
         },
         "node_modules/@websdr/nestjs-microservice": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@websdr/nestjs-microservice/-/nestjs-microservice-0.6.3.tgz",
-            "integrity": "sha512-4/OAI7vG6SbbEB4j2Zhaldauj4BjndMNvjyyr+8z+rLUyRaJujrqrGsUOUkqBcr/4WFkQEb/NmBG9LP/DbQRTA==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@websdr/nestjs-microservice/-/nestjs-microservice-0.6.4.tgz",
+            "integrity": "sha512-rf/Ig8ZBUUHoOSFBb4J6+fP6Hl38aqMbeFSZJj5V8l3wCsepXSxyKuLnHHbc2LUt3g9ou4T6NW3+oJ2EhPciKw==",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.3",
+                "@websdr/core": "^0.6.4",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.15.1",
                 "passport-jwt": "^4.0.1",
@@ -4217,13 +4217,13 @@
             }
         },
         "node_modules/@websdr/vue3-components": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@websdr/vue3-components/-/vue3-components-0.6.3.tgz",
-            "integrity": "sha512-BCr05AzHaAnz80CmJhd5bS8kSikyBdw0ukyb8VxTJVFmkafS11Y5EMHX28WKfmft9ZtuTNSNXSKg3ob/yJRvyw==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@websdr/vue3-components/-/vue3-components-0.6.4.tgz",
+            "integrity": "sha512-8x1dL8wZLxOdIUvdWJi+O8VnHaWjkJvlNCAGpOisWnQgCRSgDwdvGtsjARkRGS1UqoIET1X92LSB3HaQtPWaQg==",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.3",
-                "@websdr/frontend-core": "^0.6.3"
+                "@websdr/core": "^0.6.4",
+                "@websdr/frontend-core": "^0.6.4"
             },
             "peerDependencies": {
                 "vue": "^3.5.0"
@@ -4585,9 +4585,9 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
-            "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+            "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15703,11 +15703,11 @@
         },
         "packages/backend-core": {
             "name": "@osmoweb/backend-core",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/core": "^0.6.5",
-                "@websdr/core": "^0.6.3",
+                "@osmoweb/core": "^0.6.6",
+                "@websdr/core": "^0.6.4",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -15717,10 +15717,10 @@
         },
         "packages/core": {
             "name": "@osmoweb/core",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
-                "@websdr/core": "^0.6.3"
+                "@websdr/core": "^0.6.4"
             },
             "devDependencies": {
                 "@types/node": "^26.0.0"
@@ -15728,13 +15728,13 @@
         },
         "packages/frontend-core": {
             "name": "@osmoweb/frontend-core",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/backend-core": "^0.6.5",
-                "@osmoweb/core": "^0.6.5",
-                "@websdr/core": "^0.6.3",
-                "@websdr/frontend-core": "^0.6.3"
+                "@osmoweb/backend-core": "^0.6.6",
+                "@osmoweb/core": "^0.6.6",
+                "@websdr/core": "^0.6.4",
+                "@websdr/frontend-core": "^0.6.4"
             },
             "devDependencies": {
                 "@types/emscripten": "^1.41.5"
@@ -15742,12 +15742,12 @@
         },
         "packages/nestjs-microservice": {
             "name": "@osmoweb/nestjs-microservice",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/backend-core": "^0.6.5",
-                "@osmoweb/core": "^0.6.5",
-                "@websdr/nestjs-microservice": "^0.6.3",
+                "@osmoweb/backend-core": "^0.6.6",
+                "@osmoweb/core": "^0.6.6",
+                "@websdr/nestjs-microservice": "^0.6.4",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.15.1",
                 "passport-jwt": "^4.0.1",
@@ -15770,12 +15770,12 @@
         },
         "packages/vue3-components": {
             "name": "@osmoweb/vue3-components",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
-                "@osmoweb/core": "^0.6.5",
-                "@osmoweb/frontend-core": "^0.6.5",
-                "@websdr/vue3-components": "^0.6.3"
+                "@osmoweb/core": "^0.6.6",
+                "@osmoweb/frontend-core": "^0.6.6",
+                "@websdr/vue3-components": "^0.6.4"
             },
             "devDependencies": {
                 "@vitejs/plugin-vue": "^6.0.7",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/backend-core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "This is the core backend package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -24,8 +24,8 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/core": "^0.6.5",
-        "@websdr/core": "^0.6.3",
+        "@osmoweb/core": "^0.6.6",
+        "@websdr/core": "^0.6.4",
         "ws": "^8.21.0"
     },
     "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "This is the core package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -30,7 +30,7 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@websdr/core": "^0.6.3"
+        "@websdr/core": "^0.6.4"
     },
     "devDependencies": {
         "@types/node": "^26.0.0"

--- a/packages/frontend-core/package.json
+++ b/packages/frontend-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/frontend-core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "This is the core frontend package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -25,10 +25,10 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/core": "^0.6.5",
-        "@osmoweb/backend-core": "^0.6.5",
-        "@websdr/core": "^0.6.3",
-        "@websdr/frontend-core": "^0.6.3"
+        "@osmoweb/core": "^0.6.6",
+        "@osmoweb/backend-core": "^0.6.6",
+        "@websdr/core": "^0.6.4",
+        "@websdr/frontend-core": "^0.6.4"
     },
     "devDependencies": {
         "@types/emscripten": "^1.41.5"

--- a/packages/nestjs-microservice/package.json
+++ b/packages/nestjs-microservice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/nestjs-microservice",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "This is a NestJS microservice for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -25,9 +25,9 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/backend-core": "^0.6.5",
-        "@osmoweb/core": "^0.6.5",
-        "@websdr/nestjs-microservice": "^0.6.3",
+        "@osmoweb/backend-core": "^0.6.6",
+        "@osmoweb/core": "^0.6.6",
+        "@websdr/nestjs-microservice": "^0.6.4",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "passport-jwt": "^4.0.1",

--- a/packages/vue3-components/README.md
+++ b/packages/vue3-components/README.md
@@ -159,6 +159,18 @@ then fall back to the package primary color tokens:
 For component-level focus customization, override `--input-focus-border` and
 `--input-focus-shadow` on a wrapper element.
 
+Clear buttons use the shared `--control-clear-*` tokens from the underlying
+WebSDR component styles:
+
+```scss
+:root {
+  --control-clear-size: 1.25rem;
+  --control-clear-icon-size: 0.875rem;
+  --control-clear-radius: 0.1875rem;
+  --control-clear-hover-bg: var(--primary-bg-light, rgba(59, 130, 246, 0.1));
+}
+```
+
 #### Corporate Branding
 ```scss
 :root {

--- a/packages/vue3-components/package.json
+++ b/packages/vue3-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/vue3-components",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "This is a Vue 3 components package for OsmoWeb",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",
@@ -32,9 +32,9 @@
         "postpack": "rm -f ./LICENSE"
     },
     "dependencies": {
-        "@osmoweb/core": "^0.6.5",
-        "@osmoweb/frontend-core": "^0.6.5",
-        "@websdr/vue3-components": "^0.6.3"
+        "@osmoweb/core": "^0.6.6",
+        "@osmoweb/frontend-core": "^0.6.6",
+        "@websdr/vue3-components": "^0.6.4"
     },
     "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.7",

--- a/test-apps/package.json
+++ b/test-apps/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@osmoweb/test-apps",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "OsmoWeb package test applications",
     "author": "Timur Davydov <dtv.comp@gmail.com>",
     "license": "MIT",


### PR DESCRIPTION
Update internal package versions and align WebSDR dependencies with the 0.6.4 release.

Also document the shared clear-button design tokens inherited from the WebSDR component library.